### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -76,9 +76,6 @@ fixtures:
     stunnel:
       repo: https://github.com/simp/pupmod-simp-stunnel
       branch: master
-    sysctl:
-      repo: https://github.com/simp/pupmod-simp-sysctl
-      branch: master
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
       branch: master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 3.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Tue Nov 22 2016 Jeanne Greulich <jgreulich@onyxpoint.com> - 3.0.0-0
 - Update major version release for SIMP 6
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -13,7 +13,7 @@ Requires: pupmod-simp-simplib >= 2.0.0-0
 Requires: pupmod-simp-simplib < 3.0.0-0
 Requires: pupmod-simp-stunnel >= 5.0.0-0
 Requires: pupmod-simp-stunnel < 6.0.0-0
-Requires: pupmod-simp-sysctl >= 5.0.0-0
-Requires: pupmod-simp-sysctl < 6.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
 Requires: pupmod-simp-tcpwrappers >= 5.0.0-0
 Requires: pupmod-simp-tcpwrappers < 6.0.0-0

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -199,8 +199,7 @@ class simp_logstash::input::syslog (
         # Allow the iptables NAT rules to work properly.
         sysctl { 'net.ipv4.conf.all.route_localnet':
           ensure => 'present',
-          val    => '1',
-          silent => true
+          val    => '1'
         }
       }
     }

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -76,7 +76,7 @@
 #   connections on both TCP and UDP for devices which simply do not support
 #   encrypted connections.
 #
-# @param simp_sysctl [Boolean] If set, this class will manage the following
+# @param manage_sysctl [Boolean] If set, this class will manage the following
 #   sysctl variables.
 #   * net.ipv4.conf.all.route_localhost
 #
@@ -89,11 +89,11 @@
 # @copyright 2016 Onyx Point, Inc.
 #
 class simp_logstash::input::syslog (
-  $add_field = {},
-  $codec = '',
-  $facility_labels = [],
-  $host = '127.0.0.1',
-  $locale = '',
+  $add_field            = {},
+  $codec                = '',
+  $facility_labels      = [],
+  $host                 = '127.0.0.1',
+  $locale               = '',
   $severity_labels = [
     'Emergency',
     'Alert',
@@ -104,22 +104,22 @@ class simp_logstash::input::syslog (
     'Informational',
     'Debug'
   ],
-  $lstash_tags = '',
-  $timezone = '',
-  $lstash_type = '',
-  $use_labels = true,
-  $order = '50',
-  $content = '',
-  $client_nets           = defined('$::client_nets') ? { true => getvar('::client_nets'), default => hiera('client_nets','127.0.0.1') },
-  $listen_plain_tcp      = false,
-  $listen_plain_udp      = false,
-  $tcp_port              = '514',
-  $udp_port              = '514',
+  $lstash_tags          = '',
+  $timezone             = '',
+  $lstash_type          = '',
+  $use_labels           = true,
+  $order                = '50',
+  $content              = '',
+  $client_nets          = defined('$::client_nets') ? { true => getvar('::client_nets'), default => hiera('client_nets','127.0.0.1') },
+  $listen_plain_tcp     = false,
+  $listen_plain_udp     = false,
+  $tcp_port             = '514',
+  $udp_port             = '514',
   $daemon_port          = '51400',
-  $stunnel_syslog_input  = true,
-  $stunnel_syslog_port   = '6514',
-  $simp_sysctl           = true,
-  $simp_iptables         = defined('$::use_iptables') ? { true => getvar('::use_iptables'), default => hiera('use_iptables',true) }
+  $stunnel_syslog_input = true,
+  $stunnel_syslog_port  = '6514',
+  $manage_sysctl        = true,
+  $simp_iptables        = defined('$::use_iptables') ? { true => getvar('::use_iptables'), default => hiera('use_iptables',true) }
 ) {
 
   validate_hash($add_field)
@@ -142,7 +142,7 @@ class simp_logstash::input::syslog (
   validate_port($daemon_port)
   validate_bool($stunnel_syslog_input)
   validate_port($stunnel_syslog_port)
-  validate_bool($simp_sysctl)
+  validate_bool($manage_sysctl)
   validate_bool($simp_iptables)
 
   ### Common material to all inputs
@@ -195,11 +195,13 @@ class simp_logstash::input::syslog (
         }
       }
 
-      if $simp_sysctl {
-        include '::sysctl'
-
+      if $manage_sysctl {
         # Allow the iptables NAT rules to work properly.
-        sysctl::value { 'net.ipv4.conf.all.route_localnet': value => '1' }
+        sysctl { 'net.ipv4.conf.all.route_localnet':
+          ensure => 'present',
+          val    => '1',
+          silent => true
+        }
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_logstash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-logstash",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
       "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
-      "name": "simp/sysctl",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "name": "herculesteam-augeasproviders_sysctl",
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     },
     {
       "name": "simp/tcpwrappers",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,7 +40,6 @@ describe 'simp_logstash' do
         it { is_expected.to create_simp_logstash__filter('puppet_server') }
         it { is_expected.to create_simp_logstash__filter('slapd_audit') }
         it { is_expected.to create_simp_logstash__output('elasticsearch') }
-
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,8 +20,6 @@ describe 'simp_logstash' do
 
         it { is_expected.to_not create_iptables_rule('tcp_logstash_syslog_redirect')}
         it { is_expected.to_not create_iptables_rule('udp_logstash_syslog_redirect')}
-        it { is_expected.to_not create_sysctl__value('net.ipv4.conf.all.route_localnet')}
-        it { is_expected.to_not create_class('sysctl') }
 
         it { is_expected.to create_class('stunnel') }
         it { is_expected.to create_tcpwrappers__allow('logstash_syslog') }
@@ -42,6 +40,7 @@ describe 'simp_logstash' do
         it { is_expected.to create_simp_logstash__filter('puppet_server') }
         it { is_expected.to create_simp_logstash__filter('slapd_audit') }
         it { is_expected.to create_simp_logstash__output('elasticsearch') }
+
       end
     end
   end

--- a/spec/classes/input/syslog_spec.rb
+++ b/spec/classes/input/syslog_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'simp_logstash::input::syslog' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts){ facts }
+
+      context "on #{os}" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::input::syslog') }
+
+        context 'with listen_plain_tcp=false' do
+          it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
+        end
+
+        context 'with listen_plain_tcp=true' do 
+          let (:params) { {:listen_plain_tcp => true} }
+          it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
+
+          context 'with manage_sysctl=false' do
+            let (:params) { {:manage_sysctl => false} }
+            it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in simp_logstash
SIMP-2246 #close