### PR TITLE
SIMP-1996 TLS enable the Logstash syslog listener

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -73,9 +73,6 @@ fixtures:
     stdlib:
       repo: https://github.com/simp/puppetlabs-stdlib
       branch: simp-master
-    stunnel:
-      repo: https://github.com/simp/pupmod-simp-stunnel
-      branch: master
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
       branch: master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@
 
 * Tue Nov 22 2016 Jeanne Greulich <jgreulich@onyxpoint.com> - 3.0.0-0
 - Update major version release for SIMP 6
+- Removed stunnel and replaced it with TCP TLS input
+- Added TLS enabled JSON input
+- Updated tests
 
 * Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.0.1-0
 - Minor updates

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ follows.
   simp_logstash::input::syslog::listen_plain_tcp : true
   simp_logstash::input::syslog::listen_plain_udp : true
  
-  # This uses an stunnel connection to provide an encrypted connection so you
+  # This uses TLS to provide an encrypted connection so you
   # can only point at one node at a time. You could place this behind a load
   # balancer if you want a redundant solution.
  

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -11,9 +11,7 @@ Requires: pupmod-simp-iptables < 6.0.0-0
 Requires: pupmod-simp-iptables >= 5.0.0-0
 Requires: pupmod-simp-simplib >= 2.0.0-0
 Requires: pupmod-simp-simplib < 3.0.0-0
-Requires: pupmod-simp-stunnel >= 5.0.0-0
-Requires: pupmod-simp-stunnel < 6.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
-Requires: pupmod-simp-tcpwrappers >= 5.0.0-0
-Requires: pupmod-simp-tcpwrappers < 6.0.0-0
+Requires: pupmod-simp-pki < 6.0.0-0
+Requires: pupmod-simp-pki >= 5.0.0-0

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -1,0 +1,15 @@
+## Class: simp_logstash::config::config::pki
+#
+# This class is meant to be called from simp_logstash.
+# It ensures that pki rules are defined.
+#
+# @private
+#
+class simp_logstash::config::pki {
+  assert_private()
+
+  ::pki::copy {'/etc/logstash':
+    source => $::simp_logstash::pkiroot,
+    group  => 'logstash'
+  }
+}

--- a/manifests/filter/simp_syslog.pp
+++ b/manifests/filter/simp_syslog.pp
@@ -1,0 +1,61 @@
+# A Logstash filter for SIMP syslog parsing
+#
+# Though this class has a great deal repeated with the other filter classes,
+# they remain separate in the event that variables need to be added in the
+# future for ERB processing.
+#
+# @param order [Integer] The relative order within the configuration group. If
+#   omitted, the entries will fall in alphabetical order.
+#
+# @param content [String] The content that you wish to have in your filter. If
+#   set, this will override *all* template contents.
+#
+# @param content [String] The content that you wish to have in your filter. If
+#   set, this will override *all* template contents.
+#
+# @param severity_labels [String] Labels for severity levels.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-filters-syslog_pri.html
+#
+# @author Ralph Wright <rwright@onyxpoint.com>
+#
+# @copyright 2016 Onyx Point, Inc.
+class simp_logstash::filter::simp_syslog (
+  $order = '10',
+  $content = '',
+  $severity_labels = [
+    'Emergency',
+    'Alert',
+    'Critical',
+    'Error',
+    'Warning',
+    'Notice',
+    'Informational',
+    'Debug'
+  ]
+){
+  include '::simp_logstash'
+
+  validate_integer($order)
+  validate_string($content)
+  validate_array($severity_labels)
+
+  $_component_name = 'simp_syslog'
+  $_group = 'filter'
+  $_group_order = $::simp_logstash::config_order[$_group]
+
+  if empty($content) {
+    $_content = template("${module_name}/${_group}/${_component_name}.erb")
+  }
+  else {
+    $_content = $content
+  }
+
+  file { "${::simp_logstash::config_prefix}-${_group_order}_${_group}-${order}-${_component_name}${::simp_logstash::config_suffix}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => $::logstash::logstash_group,
+    mode    => '0640',
+    content => $_content,
+    notify  => Class['logstash::service']
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,13 +32,16 @@
 #   users to explicitly set their own configuration files as well as to prevent
 #   issues with the upstream logstash module.
 #
+# @pkiroot The source directory of the PKI certs you want to use for TLS inputs.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author Ralph Wright <rwright@onyxpoint.com>
 #
 # @copyright 2016 Onyx Point, Inc.
 #
 class simp_logstash (
   $inputs = [
-    'syslog'
+    'tcp_syslog_tls'
   ],
   $filters = [
     'audispd',
@@ -53,13 +56,15 @@ class simp_logstash (
   $outputs = [
     'elasticsearch'
   ],
-  $config_purge = true
+  $config_purge = true,
+  $pkiroot      = '/etc/pki'
 ) {
 
   validate_array($inputs)
   validate_array($filters)
   validate_array($outputs)
   validate_bool($config_purge)
+  validate_absolute_path($pkiroot)
 
   include '::java'
   include '::logstash'

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -1,11 +1,8 @@
-# A Logstash input for Syslog messages
+# A Logstash input for unencrypted Syslog messages
 #
 # Though this class has a great deal repeated with the other input classes,
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
-#
-# It allows you to encrypt traffic to the LogStash log collector just like the
-# SIMP rsyslog remote configuration.
 #
 # IPTables NAT rules are modified so that LogStash can run as a normal user
 # while collecting syslog traffic from other hosts.
@@ -25,26 +22,10 @@
 # @param codec [String] The codec used for input data.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param facility_labels [Array] Labels for facility levels.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
-#
 # @param host [String] The address upon which to listen.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param locale [String] The locale to use used for date parsing.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
-#
-# @param severity_labels [String] Labels for severity levels.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
-#
 # @param lstash_tags [Array] Arbitrary tags for your events.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
-#
-# @param timezone [String] A time zone canonical ID to be used for date
-#  parsing.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
-#
-# @param use_labels [Boolean] Use label parsing for severity and facility levels.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
 # @param order [Integer] The relative order within the configuration group. If
@@ -53,7 +34,7 @@
 # @param content [String] The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
-# @param client_nets [Array(Net Address)] An array of networks that you trust
+# @param trusted_nets [Array(Net Address)] An array of networks that you trust
 #   to connect to your server.
 #
 # @param listen_plain_tcp [Boolean] If set, listen on the default unencrypted
@@ -70,12 +51,6 @@
 #
 # @param daemon_port [Port] The port that logstash itself should listen on.
 #
-# @param stunnel_syslog_input [Boolean] Whether or not to set up a stunnel
-#   connection on port 5140 for allowing clients to send logs to the server
-#   over an encrypted channel. The usual 514 port will also listen for
-#   connections on both TCP and UDP for devices which simply do not support
-#   encrypted connections.
-#
 # @param manage_sysctl [Boolean] If set, this class will manage the following
 #   sysctl variables.
 #   * net.ipv4.conf.all.route_localhost
@@ -85,63 +60,41 @@
 #   from needing to run as the 'root' user.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author Ralph Wright <rwright@onyxpoint.com>
 #
 # @copyright 2016 Onyx Point, Inc.
 #
 class simp_logstash::input::syslog (
-  $add_field            = {},
-  $codec                = '',
-  $facility_labels      = [],
-  $host                 = '127.0.0.1',
-  $locale               = '',
-  $severity_labels = [
-    'Emergency',
-    'Alert',
-    'Critical',
-    'Error',
-    'Warning',
-    'Notice',
-    'Informational',
-    'Debug'
-  ],
-  $lstash_tags          = '',
-  $timezone             = '',
-  $lstash_type          = '',
-  $use_labels           = true,
-  $order                = '50',
-  $content              = '',
-  $client_nets          = defined('$::client_nets') ? { true => getvar('::client_nets'), default => hiera('client_nets','127.0.0.1') },
-  $listen_plain_tcp     = false,
-  $listen_plain_udp     = false,
-  $tcp_port             = '514',
-  $udp_port             = '514',
-  $daemon_port          = '51400',
-  $stunnel_syslog_input = true,
-  $stunnel_syslog_port  = '6514',
-  $manage_sysctl        = true,
-  $simp_iptables        = defined('$::use_iptables') ? { true => getvar('::use_iptables'), default => hiera('use_iptables',true) }
+  $add_field = {},
+  $codec = '',
+  $host = '127.0.0.1',
+  $lstash_tags = '',
+  $lstash_type = 'simp_syslog',
+  $order = '50',
+  $content = '',
+  $trusted_nets           = defined('$::trusted_nets') ? { true => getvar('::trusted_nets'), default => hiera('trusted_nets','127.0.0.1') },
+  $listen_plain_tcp      = true,
+  $listen_plain_udp      = false,
+  $tcp_port              = '514',
+  $udp_port              = '514',
+  $daemon_port           = '51400',
+  $manage_sysctl         = true,
+  $simp_iptables         = defined('$::use_iptables') ? { true => getvar('::use_iptables'), default => hiera('use_iptables',true) }
 ) {
 
   validate_hash($add_field)
   validate_string($codec)
-  validate_array($facility_labels)
   validate_net_list($host)
-  validate_string($locale)
-  validate_array($severity_labels)
   validate_string($lstash_tags)
-  validate_string($timezone)
   validate_string($lstash_type)
-  validate_bool($use_labels)
   validate_integer($order)
   validate_string($content)
-  validate_net_list($client_nets)
+  validate_net_list($trusted_nets)
   validate_bool($listen_plain_tcp)
   validate_bool($listen_plain_udp)
   validate_port($udp_port)
   validate_port($tcp_port)
   validate_port($daemon_port)
-  validate_bool($stunnel_syslog_input)
-  validate_port($stunnel_syslog_port)
   validate_bool($manage_sysctl)
   validate_bool($simp_iptables)
 
@@ -170,6 +123,8 @@ class simp_logstash::input::syslog (
   ### End common material
 
   if $simp_iptables {
+    include '::iptables'
+
     if $listen_plain_tcp or $listen_plain_udp {
       if $listen_plain_tcp {
         # IPTables rules so that LogStash doesn't have to run as root.
@@ -206,7 +161,7 @@ class simp_logstash::input::syslog (
 
     if $listen_plain_tcp {
       iptables::add_tcp_stateful_listen { 'logstash_syslog_tcp':
-        client_nets => $client_nets,
+        trusted_nets => $trusted_nets,
         dports      => $tcp_port
       }
       iptables_rule { 'logstash_syslog_tcp_allow':
@@ -215,25 +170,12 @@ class simp_logstash::input::syslog (
     }
     if $listen_plain_udp {
       iptables::add_udp_listen { 'logstash_syslog_udp':
-        client_nets => $client_nets,
+        trusted_nets => $trusted_nets,
         dports      => $udp_port
       }
       iptables_rule { 'logstash_syslog_udp_allow':
         content => "-d ${host} -p udp -m udp -m multiport --dports ${daemon_port} -j ACCEPT"
       }
     }
-  }
-
-  if $stunnel_syslog_input {
-    include '::stunnel'
-    include '::tcpwrappers'
-
-    stunnel::add { 'logstash_syslog_tls':
-      client  => false,
-      connect => [$daemon_port],
-      accept  => $stunnel_syslog_port
-    }
-
-    tcpwrappers::allow { ['logstash_syslog','logstash_syslog_tls']: pattern => 'ALL' }
   }
 }

--- a/manifests/input/tcp_json_tls.pp
+++ b/manifests/input/tcp_json_tls.pp
@@ -1,0 +1,101 @@
+# A Logstash input for JSON over TCP and TLS enabled.
+#
+# Though this class has a great deal repeated with the other input classes,
+# they remain separate in the event that variables need to be added in the
+# future for ERB processing.
+#
+# It allows you to encrypt traffic to a TCP port that expects to parse JSON
+#
+# This is currently configured as a catch-all type of system. There is no
+# output filtering. If you need logstash filters or additional inputs/outputs,
+# you will need to configure them separately.
+#
+# See simp_logstash::clean if you want to automatically prune your logs to
+# conserve ElasticSearch storage space.
+#
+# @param add_field [Hash] Add a field to an event.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param codec [String] The codec used for input data.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param facility_labels [Array] Labels for facility levels.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param host [String] The address upon which to listen.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param lstash_tags [Array] Arbitrary tags for your events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param order [Integer] The relative order within the configuration group. If
+#   omitted, the entries will fall in alphabetical order.
+#
+# @param content [String] The content that you wish to have in your filter. If
+#   set, this will override *all* template contents.
+#
+# @param trusted_nets [Array(Net Address)] An array of networks that you trust
+#   to connect to your server.
+#
+# @param daemon_port [Port] The port that logstash itself should listen on.
+#
+# @author Ralph Wright <rwright@onyxpoint.com>
+#
+class simp_logstash::input::tcp_json_tls (
+  $add_field = {},
+  $codec = 'json',
+  $host = '0.0.0.0',
+  $lstash_tags = '',
+  $lstash_type = 'json',
+  $order = '50',
+  $content = '',
+  $trusted_nets           = defined('$::trusted_nets') ? { true => getvar('::trusted_nets'), default => hiera('trusted_nets','127.0.0.1') },
+  $daemon_port           = '5140',
+  $ssl_verify            = true,
+  $lstash_tls_cert     = "/etc/logstash/pki/public/${::fqdn}.pub",
+  $lstash_tls_key     = "/etc/logstash/pki/private/${::fqdn}.pem",
+  $lstash_tls_cacert   = '/etc/logstash/pki/cacerts/cacerts.pem',
+) {
+
+  validate_hash($add_field)
+  validate_string($codec)
+  validate_net_list($host)
+  validate_string($lstash_tags)
+  validate_string($lstash_type)
+  validate_integer($order)
+  validate_string($content)
+  validate_net_list($trusted_nets)
+  validate_port($daemon_port)
+  validate_bool($ssl_verify)
+  validate_absolute_path($lstash_tls_cert)
+  validate_absolute_path($lstash_tls_key)
+  validate_absolute_path($lstash_tls_cacert)
+
+  include '::simp_logstash'
+  include 'simp_logstash::config::pki'
+
+  $_component_name = 'tcp_json_tls'
+  $_group = 'input'
+  $_group_order = $::simp_logstash::config_order[$_group]
+
+  if empty($content) {
+    $_content = template("${module_name}/${_group}/${_component_name}.erb")
+  }
+  else {
+    $_content = $content
+  }
+
+  file { "${::simp_logstash::config_prefix}-${_group_order}_${_group}-${order}-${_component_name}${::simp_logstash::config_suffix}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => $::logstash::logstash_group,
+    mode    => '0640',
+    content => $_content,
+    notify  => Class['logstash::service']
+  }
+
+  iptables::add_tcp_stateful_listen { "allow_${_component_name}":
+    trusted_nets => $trusted_nets,
+    dports      => $daemon_port
+  }
+}

--- a/manifests/input/tcp_syslog_tls.pp
+++ b/manifests/input/tcp_syslog_tls.pp
@@ -1,0 +1,103 @@
+# A Logstash input for syslog over TCP and TLS enabled.
+#
+# Though this class has a great deal repeated with the other input classes,
+# they remain separate in the event that variables need to be added in the
+# future for ERB processing.
+#
+# It allows you to encrypt traffic to the LogStash log collector just like the
+# SIMP rsyslog remote configuration.
+#
+# This is currently configured as a catch-all type of system. There is no
+# output filtering. If you need logstash filters or additional inputs/outputs,
+# you will need to configure them separately.
+#
+# @note This class is incompatible with the SIMP rsyslog::stock::server class!
+#
+# See simp_logstash::clean if you want to automatically prune your logs to
+# conserve ElasticSearch storage space.
+#
+# @param add_field [Hash] Add a field to an event.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param codec [String] The codec used for input data.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param host [String] The address upon which to listen.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param lstash_tags [Array] Arbitrary tags for your events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+#
+# @param order [Integer] The relative order within the configuration group. If
+#   omitted, the entries will fall in alphabetical order.
+#
+# @param content [String] The content that you wish to have in your filter. If
+#   set, this will override *all* template contents.
+#
+# @param trusted_nets [Array(Net Address)] An array of networks that you trust
+#   to connect to your server.
+#
+# @param daemon_port [Port] The port that logstash itself should listen on.
+#
+# @author Ralph Wright <rwright@onyxpoint.com>
+#
+#
+class simp_logstash::input::tcp_syslog_tls (
+  $add_field = {},
+  $codec = '',
+  $host = '0.0.0.0',
+  $lstash_tags = '',
+  $lstash_type = 'simp_syslog',
+  $order = '50',
+  $content = '',
+  $trusted_nets        = defined('$::trusted_nets') ? { true => getvar('::trusted_nets'), default => hiera('trusted_nets','127.0.0.1') },
+  $daemon_port        = '6514',
+  $ssl_verify         = true,
+  $lstash_tls_cert    = "/etc/logstash/pki/public/${::fqdn}.pub",
+  $lstash_tls_key     = "/etc/logstash/pki/private/${::fqdn}.pem",
+  $lstash_tls_cacert  = '/etc/logstash/pki/cacerts/cacerts.pem',
+) {
+
+  validate_hash($add_field)
+  validate_string($codec)
+  validate_net_list($host)
+  validate_string($lstash_tags)
+  validate_string($lstash_type)
+  validate_integer($order)
+  validate_string($content)
+  validate_net_list($trusted_nets)
+  validate_port($daemon_port)
+  validate_bool($ssl_verify)
+  validate_absolute_path($lstash_tls_cert)
+  validate_absolute_path($lstash_tls_key)
+  validate_absolute_path($lstash_tls_cacert)
+
+  include '::simp_logstash'
+  include 'simp_logstash::config::pki'
+  include 'simp_logstash::filter::simp_syslog'
+
+  $_component_name = 'tcp_syslog_tls'
+  $_group = 'input'
+  $_group_order = $::simp_logstash::config_order[$_group]
+
+  if empty($content) {
+    $_content = template("${module_name}/${_group}/${_component_name}.erb")
+  }
+  else {
+    $_content = $content
+  }
+
+  file { "${::simp_logstash::config_prefix}-${_group_order}_${_group}-${order}-${_component_name}${::simp_logstash::config_suffix}":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => $::logstash::logstash_group,
+    mode    => '0640',
+    content => $_content,
+    notify  => Class['logstash::service']
+  }
+
+  iptables::add_tcp_stateful_listen { "allow_${_component_name}":
+    trusted_nets => $trusted_nets,
+    dports       => $daemon_port
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -43,6 +43,10 @@
     {
       "name": "simp/tcpwrappers",
       "version_requirement": ">= 5.0.0 < 6.0.0"
+    },
+    {
+      "name": "simp/pki",
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -7,8 +7,7 @@ HOSTS:
       - logstash_server
       - el7
     platform:   el-7-x86_64
-    box:        puppetlabs/centos-7.0-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    box:        centos/7
     hypervisor: vagrant
     yum_repos:
       logstash:
@@ -26,10 +25,8 @@ HOSTS:
       - agent
       - el7
     platform:   el-7-x86_64
-    box:        puppetlabs/centos-7.0-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    box:        centos/7
     hypervisor: vagrant
-    simp_update_url : https://dl.bintray.com/simp/5.1.X
     yum_repos:
       epel:
         url: 'http://download.fedoraproject.org/pub/epel/7/$basearch'
@@ -41,8 +38,7 @@ HOSTS:
       - logstash_server
       - el6
     platform:   el-6-x86_64
-    box:        puppetlabs/centos-6.6-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    box:        centos/6
     hypervisor: vagrant
     yum_repos:
       logstash:
@@ -60,10 +56,8 @@ HOSTS:
       - agent
       - el6
     platform:   el-6-x86_64
-    box:        puppetlabs/centos-6.6-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    box:        centos/6
     hypervisor: vagrant
-    simp_update_url : https://dl.bintray.com/simp/4.2.X
     yum_repos:
       epel:
         url: 'http://download.fedoraproject.org/pub/epel/6/$basearch'
@@ -74,4 +68,4 @@ CONFIG:
   log_level: verbose
   type:      foss
   vagrant_memsize: 512
-  # vb_gui: true
+  #vb_gui: true

--- a/spec/acceptance/suites/default/02_client_server_with_tls_spec.rb
+++ b/spec/acceptance/suites/default/02_client_server_with_tls_spec.rb
@@ -34,7 +34,7 @@ describe 'rsyslog client -> 1 server with TLS' do
 
         it 'should successfully send log messages' do
           on client, 'logger -t FOO 02-TEST-WITH-TLS'
-          sleep(5)
+          sleep(15)
           remote_log = '/var/log/logstash/file_output.log'
           on server, "test -f #{remote_log}"
           on server, "grep 02-TEST-WITH-TLS #{remote_log}"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,25 +6,42 @@ describe 'simp_logstash' do
       let(:facts){ facts }
 
       context "on #{os}" do
+        let(:params) {{
+          :inputs => ['tcp_syslog_tls','syslog','tcp_json_tls'],
+        }}
+
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('simp_logstash') }
         it { is_expected.to create_simp_logstash__input('syslog') }
+        it { is_expected.to create_simp_logstash__input('tcp_syslog_tls') }
+        it { is_expected.to create_simp_logstash__input('tcp_json_tls') }
 
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_syslog_tls.conf'
+          ).without_content(/=>\s*$/)
+        }
         it {
           is_expected.to create_file(
             '/etc/logstash/conf.d/simp-logstash-10_input-50-syslog.conf'
           ).without_content(/=>\s*$/)
         }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_json_tls.conf'
+          ).without_content(/=>\s*$/)
+        }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-20_filter-10-simp_syslog.conf'
+          ).without_content(/=>\s*$/)
+        }
+
+        it { is_expected.to contain_class('simp_logstash::config::pki') }
 
         it { is_expected.to create_class('iptables') }
 
-        it { is_expected.to_not create_iptables_rule('tcp_logstash_syslog_redirect')}
-        it { is_expected.to_not create_iptables_rule('udp_logstash_syslog_redirect')}
-
-        it { is_expected.to create_class('stunnel') }
-        it { is_expected.to create_tcpwrappers__allow('logstash_syslog') }
-        it { is_expected.to create_tcpwrappers__allow('logstash_syslog_tls') }
-        it { is_expected.to create_stunnel__add('logstash_syslog_tls') }
+        it { is_expected.to create_iptables_rule('tcp_logstash_syslog_redirect')}
 
         it {
           is_expected.to create_file(

--- a/spec/classes/input/syslog_spec.rb
+++ b/spec/classes/input/syslog_spec.rb
@@ -8,19 +8,21 @@ describe 'simp_logstash::input::syslog' do
       context "on #{os}" do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('simp_logstash::input::syslog') }
-
-        context 'with listen_plain_tcp=false' do
-          it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
-        end
+        it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
 
         context 'with listen_plain_tcp=true' do 
           let (:params) { {:listen_plain_tcp => true} }
           it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
+        end
 
-          context 'with manage_sysctl=false' do
-            let (:params) { {:manage_sysctl => false} }
-            it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
-          end
+        context 'with listen_plain_udp=true' do 
+          let (:params) { {:listen_plain_udp => true} }
+          it { is_expected.to create_iptables_rule('udp_logstash_syslog_redirect')}
+        end
+
+        context 'with manage_sysctl=false' do
+          let (:params) { {:manage_sysctl => false} }
+          it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
         end
       end
     end

--- a/templates/filter/simp_syslog.erb
+++ b/templates/filter/simp_syslog.erb
@@ -1,0 +1,17 @@
+# This file managed by Puppet
+# # Any changes will be overwritten
+
+filter {
+  if [type] == "simp_syslog" {
+    grok {
+      match => {"message" => "<%%{POSINT:priority}>%{SYSLOGLINE}"}
+      overwrite => "message"
+      tag_on_failure => ["_grokparsefailure_sysloginput"]
+    }
+    syslog_pri {
+<% unless @severity_labels.empty? -%>
+    severity_labels => [ "<%= @severity_labels.join('", "') %>" ]
+<% end -%>
+    }
+  }
+}

--- a/templates/input/syslog.erb
+++ b/templates/input/syslog.erb
@@ -1,5 +1,6 @@
 input {
-  syslog {
+<% if @listen_plain_tcp -%>
+  tcp {
 <% unless @add_field.empty? -%>
     add_field => {
     <%=
@@ -10,28 +11,41 @@ input {
     }
 <% end -%>
 <% unless @codec.empty? -%>
-    codec => <%= @codec %>
-<% end -%>
-<% unless @facility_labels.empty? -%>
-    facility_labels => [ "<%= @facility_labels.join('", "') %>" ]
+    codec => "<%= @codec %>"
 <% end -%>
     host => "<%= @host %>"
-<% unless @locale.empty? -%>
-    locale => "<%= @locale %>"
-<% end -%>
     port => <%= @daemon_port %>
-<% unless @severity_labels.empty? -%>
-    severity_labels => [ "<%= @severity_labels.join('", "') %>" ]
+<% unless @lstash_type.empty? -%>
+    type => "<%= @lstash_type %>"
 <% end -%>
 <% unless @lstash_tags.empty? -%>
     tags => [ "<%= @lstash_tags.join('", "') %>" ]
 <% end -%>
-<% unless @timezone.empty? -%>
-    timezone => "<%= @timezone %>"
+  }
 <% end -%>
+
+<% if @listen_plain_udp -%>
+  udp {
+<% unless @add_field.empty? -%>
+    add_field => {
+    <%=
+      @add_field.keys.map do |k|
+        k = %("#{k}" => "#{@add_field[k]}")
+      end.join("\n      ")
+    %>
+    }
+<% end -%>
+<% unless @codec.empty? -%>
+    codec => "<%= @codec %>"
+<% end -%>
+    host => "<%= @host %>"
+    port => <%= @daemon_port %>
 <% unless @lstash_type.empty? -%>
     type => "<%= @lstash_type %>"
 <% end -%>
-    use_labels => <%= @use_labels %>
+<% unless @lstash_tags.empty? -%>
+    tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
   }
+<% end -%>
 }

--- a/templates/input/tcp_json_tls.erb
+++ b/templates/input/tcp_json_tls.erb
@@ -1,0 +1,29 @@
+input {
+  tcp {
+<% unless @add_field.empty? -%>
+    add_field => {
+    <%=
+      @add_field.keys.map do |k|
+        k = %("#{k}" => "#{@add_field[k]}")
+      end.join("\n      ")
+    %>
+    }
+<% end -%>
+<% unless @codec.empty? -%>
+    codec => "<%= @codec %>"
+<% end -%>
+    host => "<%= @host %>"
+    port => <%= @daemon_port %>
+<% unless @lstash_tags.empty? -%>
+    tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
+<% unless @lstash_type.empty? -%>
+    type => "<%= @lstash_type %>"
+<% end -%>
+    ssl_enable => true
+    ssl_verify => <%= @ssl_verify %>
+    ssl_extra_chain_certs => "<%= @lstash_tls_cacert %>"
+    ssl_key   => "<%= @lstash_tls_key %>"
+    ssl_cert  => "<%= @lstash_tls_cert %>"
+  }
+}

--- a/templates/input/tcp_syslog_tls.erb
+++ b/templates/input/tcp_syslog_tls.erb
@@ -1,0 +1,29 @@
+input {
+  tcp {
+<% unless @add_field.empty? -%>
+    add_field => {
+    <%=
+      @add_field.keys.map do |k|
+        k = %("#{k}" => "#{@add_field[k]}")
+      end.join("\n      ")
+    %>
+    }
+<% end -%>
+<% unless @codec.empty? -%>
+    codec => "<%= @codec %>"
+<% end -%>
+    host => "<%= @host %>"
+    port => <%= @daemon_port %>
+<% unless @lstash_tags.empty? -%>
+    tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
+<% unless @lstash_type.empty? -%>
+    type => "<%= @lstash_type %>"
+<% end -%>
+    ssl_enable => true
+    ssl_verify => <%= @ssl_verify %>
+    ssl_extra_chain_certs => "<%= @lstash_tls_cacert %>"
+    ssl_key   => "<%= @lstash_tls_key %>"
+    ssl_cert  => "<%= @lstash_tls_cert %>"
+  }
+}


### PR DESCRIPTION
- Adds TLS support and remove stunnel.
- Tests have been adjusted to use/test for TLS.
- An additional listener has been added for JSON.

SIMP-1996 #comment Acceptance tests were working but are broken now with
presumably due to all of the moving parts.
SIMP-1996 #close