### PR TITLE
(SIMP-3118) Updated simp_logstash to Logstash 5.X

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -31,11 +31,9 @@ fixtures:
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
       ref: 5.2.0
-#FIXME: Use PR for 5.X update to pupmod-simp-simp_elasticsearch until this is merged.
-#    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
     simp_elasticsearch:
       repo: https://github.com/lnemsick-simp/pupmod-simp-simp_elasticsearch
-      branch: SIMP-3048
+      branch: master
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -29,9 +29,7 @@ fixtures:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
     elasticsearch:
-#FIXME: Need newer version than is available in our fork
-#      repo: https://github.com/simp/puppet-elasticsearch
-      repo: https://github.com/elastic/puppet-elasticsearch
+      repo: https://github.com/simp/puppet-elasticsearch
       ref: 5.2.0
 #FIXME: Use PR for 5.X update to pupmod-simp-simp_elasticsearch until this is merged.
 #    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
@@ -54,12 +52,8 @@ fixtures:
       repo: https://github.com/simp/pupmod-simp-logrotate
       ref: 6.0.0
     logstash:
-#FIXME: Workaround until strict variables problem until logstash
-# PR #330 gets merged
-#      repo: https://github.com/simp/puppet-logstash
-#      ref: 5.1.0
-      repo: https://github.com/lnemsick-simp/puppet-logstash
-      branch: SIMP-3118
+      repo: https://github.com/simp/puppet-logstash
+      branch: 5.2.1
     oddjob:
       repo: https://github.com/simp/pupmod-simp-oddjob
       ref: 2.0.0

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,88 +1,103 @@
 ---
 fixtures:
   repositories:
-    simp_apache:
-      repo: https://github.com/simp/pupmod-simp-apache
-      branch: master
     auditd:
       repo: https://github.com/simp/pupmod-simp-auditd
-      branch: master
+      ref: 7.0.1
     augeasproviders_core:
       repo: https://github.com/simp/augeasproviders_core
-      branch: simp-master
+      ref: simp6.0.0-2.1.3
     augeasproviders_grub:
       repo: https://github.com/simp/augeasproviders_grub
-      branch: simp-master
+      ref: simp6.0.0-2.4.0
     augeasproviders_puppet:
       repo: https://github.com/simp/augeasproviders_puppet
-      branch: simp-master
+      ref: simp-2.1.0
     augeasproviders_ssh:
       repo: https://github.com/simp/augeasproviders_ssh
-      branch: simp-master
+      ref: simp6.0.0-2.5.0
     augeasproviders_sysctl:
       repo: https://github.com/simp/augeasproviders_sysctl
-      branch: simp-master
+      ref: simp6.0.0-2.1.0
     compliance_mapper:
       repo: https://github.com/simp/pupmod-simp-compliance_markup
-      branch: master
+      ref: 2.0.1
     concat:
       repo: https://github.com/simp/puppetlabs-concat
-      branch: simp-master
+      ref: simp6.0.0-2.2.0
     datacat:
       repo: https://github.com/simp/puppet-datacat
-      branch: simp-master
+      ref: simp6.0.0-0.6.2
     elasticsearch:
-      repo: https://github.com/simp/puppet-elasticsearch
-      branch: simp-master
-    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
+#FIXME: Need newer version than is available in our fork
+#      repo: https://github.com/simp/puppet-elasticsearch
+      repo: https://github.com/elastic/puppet-elasticsearch
+      ref: 5.2.0
+#FIXME: Use PR for 5.X update to pupmod-simp-simp_elasticsearch until this is merged.
+#    simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
+    simp_elasticsearch:
+      repo: https://github.com/lnemsick-simp/pupmod-simp-simp_elasticsearch
+      branch: SIMP-3048
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
-      branch: simp-master
+      ref: simp6.0.0-1.0.1
     haveged:
       repo: https://github.com/simp/puppet-haveged
-      branch: simp-master
+      ref: 0.4.0
     iptables:
       repo: https://github.com/simp/pupmod-simp-iptables
-      branch: master
+      ref: 6.0.1
     java:
       repo: https://github.com/simp/puppetlabs-java
-      branch: simp-master
+      ref: simp-1.6.0-post1
     logrotate:
       repo: https://github.com/simp/pupmod-simp-logrotate
-      branch: master
+      ref: 6.0.0
     logstash:
-      repo: https://github.com/simp/puppet-logstash
-      branch: simp-master
+#FIXME: Workaround until strict variables problem until logstash
+# PR #330 gets merged
+#      repo: https://github.com/simp/puppet-logstash
+#      ref: 5.1.0
+      repo: https://github.com/lnemsick-simp/puppet-logstash
+      branch: SIMP-3118
     oddjob:
       repo: https://github.com/simp/pupmod-simp-oddjob
-      branch: master
+      ref: 2.0.0
     pam:
       repo: https://github.com/simp/pupmod-simp-pam
-      branch: master
+      ref: 6.0.2
     pki:
       repo: https://github.com/simp/pupmod-simp-pki
-      branch: master
+      ref: 6.0.0
     rsync:
       repo: https://github.com/simp/pupmod-simp-rsync
-      branch: master
+      ref: 6.0.2
     rsyslog:
       repo: https://github.com/simp/pupmod-simp-rsyslog
-      branch: master
+      ref: 7.0.2
     simpcat:
       repo: https://github.com/simp/pupmod-simp-concat
-      branch: master
+      ref: 6.0.0
     simplib:
       repo: https://github.com/simp/pupmod-simp-simplib
-      branch: master
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
+      ref: 3.2.0
+    simp_apache:
+      repo: https://github.com/simp/pupmod-simp-apache
+      ref: 6.0.0
+    simp_options: 
+      repo: https://github.com/simp/pupmod-simp-simp_options
+      ref: 1.0.2
     stdlib:
       repo: https://github.com/simp/puppetlabs-stdlib
-      branch: master
+      ref: simp6.0.0-4.13.1
     stunnel:
       repo: https://github.com/simp/pupmod-simp-stunnel
-      branch: master
+      ref: 6.0.1
     tcpwrappers:
       repo: https://github.com/simp/pupmod-simp-tcpwrappers
-      branch: master
+      ref: 6.0.0
+    yum:
+      repo: https://github.com/voxpupuli/puppet-yum
+      ref: v1.0.0
   symlinks:
     simp_logstash: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
-sudo: true
+sudo: false
 cache: bundler
 before_script:
   - bundle
@@ -24,17 +27,18 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,6 @@
 - Fixed enum typo in enum for simp_logstash::output::elasticsearch::script_type
 - Fixed puppet strings problems.
 
-
 * Fri Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 3.0.1-0
 - Removed pupmod-simp-sysctl in favor of augeas-sysctl
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Fri Apr 05 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+- Updated to LogStash 5.X
+- Fixed type bug in simp_logstash::output::elasticsearch::action.
+- Fixed enum typo in enum for simp_logstash::output::elasticsearch::script_type
+- Fixed puppet strings problems.
+
+
 * Fri Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 3.0.1-0
 - Removed pupmod-simp-sysctl in favor of augeas-sysctl
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Fri Apr 05 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
-- Updated to LogStash 5.X
+- Updated to LogStash 5.X and Elasticsearch 5.X
 - Fixed type bug in simp_logstash::output::elasticsearch::action.
 - Fixed enum typo in enum for simp_logstash::output::elasticsearch::script_type
 - Fixed puppet strings problems.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,22 @@
+# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
 # ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
-# ------------------------------------------------------------------------------
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources   = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~>4.8.0') # Default to SIMP 6
   gem 'rspec'
   gem 'rspec-puppet'
+  gem 'puppet-strings'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
-  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.5')
 end
 
 group :development do
@@ -35,8 +34,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker' , :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
+  gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
 end

--- a/README.rst
+++ b/README.rst
@@ -98,12 +98,12 @@ commercial solutions from Elastic, or you can apply the `SIMP IPSec Module`_.
   ---
   # The networks that you want to allow to connect to your systems
  
-  client_nets:
+  simp_options::trusted_nets:
    - '1.2.3.4/16'
  
   # For the IPTables redirects to the unprivileged Logstash process
  
-  use_iptables : true
+  simp_options::firewall : true
  
   # Elasticsearch Settings
   #
@@ -127,12 +127,6 @@ commercial solutions from Elastic, or you can apply the `SIMP IPSec Module`_.
  
   # Logstash Settings
  
-  # This is currently required due to a bug in the Elastic provided 'logstash'
-  # module
- 
-  logstash::logstash_user : 'logstash'
-  logstash::logstash_group : 'logstash'
- 
   # If you want Unencrypted UDP and TCP logs (requires SIMP IPTables)
  
   simp_logstash::input::syslog::listen_plain_tcp : true
@@ -142,6 +136,15 @@ commercial solutions from Elastic, or you can apply the `SIMP IPSec Module`_.
  
   simp_logstash::outputs :
     - 'elasticsearch'
+
+
+In addition, for EL6 systems, ensure the correct version of JAVA is
+installed as follows:
+
+.. code:: yaml
+
+  java::package : 'java-1.8.0-openjdk-devel'
+
 
 Directing Logstash to an External Elasticsearch System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,12 +162,12 @@ follows.
   ---
   # The networks that you want to allow to connect to your systems
  
-  client_nets:
+  simp_options::trusted_nets:
    - '1.2.3.4/16'
  
   # For the IPTables redirects to the unprivileged Logstash process
  
-  use_iptables : true
+  simp_options::firewall : true
  
   # Logstash Settings
  
@@ -190,6 +193,11 @@ follows.
   simp_logstash::outputs :
     - 'elasticsearch'
 
+Be sure to specify the correct version of JAVA for EL6 systems as follows:
+
+.. code:: yaml
+
+  java::package : 'java-1.8.0-openjdk-devel'
 
 Setting up the Elasticsearch System
 """""""""""""""""""""""""""""""""""

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,7 @@
 # Drop all Requires, Obsoletes, and Provides statements in here
 Provides: pupmod-simp-logstash
 Obsoletes: pupmod-simp-logstash < 2.0.0
-Requires: pupmod-elastic-logstash >= 5.0.3
+Requires: pupmod-elastic-logstash >= 5.2.1
 Requires: pupmod-elastic-logstash < 6.0.0
 Requires: pupmod-puppetlabs-java >= 1.2.0
 Requires: pupmod-puppetlabs-java < 2.0.0

--- a/manifests/clean.pp
+++ b/manifests/clean.pp
@@ -1,55 +1,54 @@
 # Create a cron job to clean your ElasticSearch indices on a regular basis
 # using elasticsearch-curator.
 #
-# @param ensure [String] Whether to add, or delete, the index job.
+# @param ensure Whether to add, or delete, the index job.
 #   Allowed Values: *present*, absent
 #
-# @param host [Hostname] The host upon which to operate. Ideally, you will
+# @param host The host upon which to operate. Ideally, you will
 #   position this job locally but it will work over thet network just as well
 #   provided your access controls allow it.
 #
-# @param keep_days [Integer] The number of days to keep within ElasticSearch.
+# @param keep_days The number of days to keep within ElasticSearch.
 #   Mutually exclusive with keep_hours and keep_space.
 #
-# @param keep_hours [Integer] The number of hours to keep within ElasticSearch.
+# @param keep_hours The number of hours to keep within ElasticSearch.
 #   Mutually exclusive with keep_days and keep_space.
 #
-# @param keep_space [Integer] The number of Gigabytes to keep within
+# @param keep_space The number of Gigabytes to keep within
 #   ElasticSearch. This applies to each index individually, not the entire
 #   storage space used by the prefix. Mutually exclusive with keep_days and
 #   keep_hours.
 #
-# @param prefix [String] The prefix to use to identify relevant logs.  This is
+# @param prefix The prefix to use to identify relevant logs.  This is
 #   a match so 'foo' will match 'foo', 'foosball', and 'foot'.
 #
-# @param port [Port] The port to which to connect. Since this is SIMP tailored,
+# @param port The port to which to connect. Since this is SIMP tailored,
 #   we use our local unencrypted default.
 #
-# @param separator [Char] The index separator.
+# @param separator The index separator.
 #
-# @param es_timeout [Integer] The timeout, in seconds, to wait for a response
+# @param es_timeout The timeout, in seconds, to wait for a response
 #   from Elasticsearch.
 #
-# @param log_file [Absolute Path] The log file to which to print curator
+# @param log_file The log file to which to print curator
 #   output.
 #
-# @param cron_hour [Integer or '*'] The hour at which to run the index cleanup.
+# @param cron_hour The hour at which to run the index cleanup.
 #
-# @param cron_minute [Integer or '*'] The minute at which to run the index
+# @param cron_minute The minute at which to run the index
 #   cleanup.
 #
-# @param cron_month [Integer or '*'] The month within which to run the index
+# @param cron_month The month within which to run the index
 #   cleanup.
 #
-# @param cron_monthday [Integer or '*'] The day of the month upon which to run
+# @param cron_monthday The day of the month upon which to run
 #   the index cleanup.
 #
-# @param cron_weekday [Integer or '*'] The day of the week upon which to run
+# @param cron_weekday  The day of the week upon which to run
 #   the index cleanup.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::clean (
   Enum['present','absent']          $ensure         = 'present',
   Simplib::Host                     $host           = '127.0.0.1',

--- a/manifests/curator.pp
+++ b/manifests/curator.pp
@@ -1,4 +1,4 @@
-# A class to include the ElasticSearch curator
+# A class to include the Elasticsearch curator
 #
 # This should probably be moved into the simp_elasticsearch module
 class simp_logstash::curator {

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -8,7 +8,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 define simp_logstash::filter {
   include "::simp_logstash::filter::${name}"
 }

--- a/manifests/filter/audispd.pp
+++ b/manifests/filter/audispd.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::audispd (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/httpd.pp
+++ b/manifests/filter/httpd.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::httpd (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/puppet_agent.pp
+++ b/manifests/filter/puppet_agent.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::puppet_agent (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/puppet_server.pp
+++ b/manifests/filter/puppet_server.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::puppet_server (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/simp_syslog.pp
+++ b/manifests/filter/simp_syslog.pp
@@ -2,23 +2,22 @@
 #   there are aspect specific to SIMP log processing, it's called simp_syslog
 #   so it won't conflict with any other more generic syslog processors.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order. We set this filter to
 #   10 so that it can process logs before the rest of our filters.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
-# @param severity_labels [String] Labels for severity levels.
+# @param severity_labels Labels for severity levels.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-filters-syslog_pri.html
 #
 # @author Ralph Wright <rwright@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::simp_syslog (
-  Integer                       $order            = 10,
-  Optional[String]              $content          = undef,
-  $severity_labels  = [
+  Integer[0]        $order            = 10,
+  Optional[String]  $content          = undef,
+  Array[String]     $severity_labels  = [
     'Emergency',
     'Alert',
     'Critical',

--- a/manifests/filter/slapd_audit.pp
+++ b/manifests/filter/slapd_audit.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::slapd_audit (
-  Integer           $order = 50,
+  Integer[0]        $order = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/sshd.pp
+++ b/manifests/filter/sshd.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::sshd (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/sudosh.pp
+++ b/manifests/filter/sudosh.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::sudosh (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/filter/yum.pp
+++ b/manifests/filter/yum.pp
@@ -4,17 +4,16 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::filter::yum (
-  Integer           $order   = 50,
+  Integer[0]        $order   = 50,
   Optional[String]  $content = undef
 ){
   include '::simp_logstash'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,11 @@
 #   logstash::java_options : ['-Xms10g', '-Xmx10g']
 #
 # See simp_logstash::clean if you want to automatically prune your logs to
-# conserve ElasticSearch storage space.
+# conserve Elasticsearch storage space.
+#
+# See simp_logstash::optimize if you want to automatically merge
+# Elasticsearch log segments to conserve storage space and speed up
+# cluster recovery after Elasticsearch restart.
 #
 # @param inputs An Array of inputs to be enabled. These can
 #   also be individually enabled by class.

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -8,7 +8,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 define simp_logstash::input {
   include "::simp_logstash::input::${name}"
 }

--- a/manifests/input/stdin.pp
+++ b/manifests/input/stdin.pp
@@ -2,19 +2,42 @@
 #
 # The generic stdin input.
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param add_field Add a field to an event.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param codec The codec used for input data.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param enable_metric Whether to enable metric logging for this plugin instance.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param id Unique ID for this input plugin configuration.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param lstash_tags Arbitrary tags for your events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param lstash_type Type field to be added to all stdin events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-stdin.html
+#
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 #
 class simp_logstash::input::stdin (
-  Integer           $order    = 50,
-  Optional[String]  $content  = undef
+  Optional[Hash]          $add_field     = undef,
+  Optional[String]        $codec         = undef,
+  Optional[Boolean]       $enable_metric = undef,
+  Optional[String]        $id            = 'simp_stdin',
+  Optional[Array[String]] $lstash_tags   = undef,
+  String                  $lstash_type   = 'simp_stdin',
+  Integer[0]              $order         = 50,
+  Optional[String]        $content       = undef
 ){
 
   ### Common material to all inputs
@@ -36,7 +59,7 @@ class simp_logstash::input::stdin (
     owner   => 'root',
     group   => $::logstash::logstash_group,
     mode    => '0640',
-    content => "input { stdin{ } }\n",
+    content => $_content,
     notify  => Class['logstash::service']
   }
   ### End common material

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -14,7 +14,7 @@
 # @note This class is incompatible with the SIMP rsyslog::stock::server class!
 #
 # See simp_logstash::clean if you want to automatically prune your logs to
-# conserve ElasticSearch storage space.
+# conserve Elasticsearch storage space.
 #
 # @param add_field Add a field to an event.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -16,70 +16,75 @@
 # See simp_logstash::clean if you want to automatically prune your logs to
 # conserve ElasticSearch storage space.
 #
-# @param add_field [Hash] Add a field to an event.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+# @param add_field Add a field to an event.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param codec [String] The codec used for input data.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+# @param codec The codec used for input data.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param host [IP] The address upon which to listen.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+# @param enable_metric Whether to enable metric logging for this plugin instance.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param lstash_tags [Array] Arbitrary tags for your events.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+# @param host The address upon which to listen.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param id Unique ID for this input plugin configuration.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param lstash_tags Arbitrary tags for your events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param lstash_type Type field to be added to all syslog events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
-# @param trusted_nets [Array(Net List)] An array of networks that you trust
-#   to connect to your server.
-#
-# @param listen_plain_tcp [Boolean] If set, listen on the default unencrypted
+# @param listen_plain_tcp If set, listen on the default unencrypted
 #   TCP syslog port. Default is true.
 #
-# @param listen_plain_udp [Boolean] If set, listen on the default unencrypted
+# @param listen_plain_udp If set, listen on the default unencrypted
 #   UDP syslog port. Default is false.
 #
-# @param tcp_port [Port] The port upon which to listen for TCP syslog
+# @param tcp_port The port upon which to listen for TCP syslog
 #   connections.
 #
-# @param udp_port [Port] The port upon which to listen for UDP syslog
+# @param udp_port The port upon which to listen for UDP syslog
 #   connections.
 #
-# @param daemon_port [Port] The port that logstash itself should listen on.
+# @param daemon_port  The port that logstash itself should listen on.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param manage_sysctl [Boolean] If set, this class will manage the following
-#   sysctl variables.
+# @param proxy_protocol Whether to support proxy protocol, v1.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param manage_sysctl If set, this class will manage the following
+#   sysctl variables when the firewall is enabled.
 #   * net.ipv4.conf.all.route_localhost
-#
-# @param firewall [Boolean] If set, use IPTables rules to forward remote
-#   connections to the logstash syslog listener. This prevents logstash itself
-#   from needing to run as the 'root' user.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 # @author Ralph Wright <rwright@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
-#
 class simp_logstash::input::syslog (
   Optional[Hash]          $add_field        = undef,
   Optional[String]        $codec            = undef,
+  Optional[Boolean]       $enable_metric    = undef,
   Optional[Simplib::IP]   $host             = '127.0.0.1',
+  Optional[String]        $id               = 'simp_syslog',
   Optional[Array[String]] $lstash_tags      = undef,
   String                  $lstash_type      = 'simp_syslog',
   Integer[0]              $order            = 50,
   Optional[String]        $content          = undef,
-  Simplib::Netlist        $trusted_nets     = simplib::lookup('simp_options::trusted_nets', {'default_value' => ['127.0.0.1/32'] }),
   Boolean                 $listen_plain_tcp = true,
   Boolean                 $listen_plain_udp = false,
   Simplib::Port           $tcp_port         = 514,
   Simplib::Port           $udp_port         = 514,
   Simplib::Port           $daemon_port      = 51400,
-  Boolean                 $manage_sysctl    = true,
-  Boolean                 $firewall         = simplib::lookup('simp_options::firewall', { 'default_value'    =>  true})
+  Optional[Boolean]       $proxy_protocol   = undef,
+  Boolean                 $manage_sysctl    = true
 ) {
 
   ### Common material to all inputs
@@ -108,7 +113,7 @@ class simp_logstash::input::syslog (
 
   include 'simp_logstash::filter::simp_syslog'
 
-  if $firewall {
+  if $::simp_logstash::firewall {
     include '::iptables'
 
     if $listen_plain_tcp or $listen_plain_udp {
@@ -147,7 +152,7 @@ class simp_logstash::input::syslog (
 
     if $listen_plain_tcp {
       iptables::listen::tcp_stateful { 'logstash_syslog_tcp':
-        trusted_nets => $trusted_nets,
+        trusted_nets => $simp_logstash::trusted_nets,
         dports       => $tcp_port
       }
       iptables_rule { 'logstash_syslog_tcp_allow':
@@ -156,7 +161,7 @@ class simp_logstash::input::syslog (
     }
     if $listen_plain_udp {
       iptables::listen::udp { 'logstash_syslog_udp':
-        trusted_nets => $trusted_nets,
+        trusted_nets => $simp_logstash::trusted_nets,
         dports       => $udp_port
       }
       iptables_rule { 'logstash_syslog_udp_allow':

--- a/manifests/input/tcp_syslog_tls.pp
+++ b/manifests/input/tcp_syslog_tls.pp
@@ -12,7 +12,7 @@
 # you will need to configure them separately.
 #
 # See simp_logstash::clean if you want to automatically prune your logs to
-# conserve ElasticSearch storage space.
+# conserve Elasticsearch storage space.
 #
 # @param add_field Add a field to an event.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html

--- a/manifests/input/tcp_syslog_tls.pp
+++ b/manifests/input/tcp_syslog_tls.pp
@@ -6,7 +6,6 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# It allows you to encrypt traffic to a TCP port that expects to parse JSON
 #
 # This is currently configured as a catch-all type of system. There is no
 # output filtering. If you need logstash filters or additional inputs/outputs,
@@ -15,43 +14,65 @@
 # See simp_logstash::clean if you want to automatically prune your logs to
 # conserve ElasticSearch storage space.
 #
-# @param add_field [Hash] Add a field to an event.
+# @param add_field Add a field to an event.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param codec [String] The codec used for input data.
+# @param codec The codec used for input data.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param facility_labels [Array] Labels for facility levels.
+# @param enable_metric Whether to enable metric logging for this plugin instance.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param host The address upon which to listen.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param host [String] The address upon which to listen.
+# @param id Unique ID for this input plugin configuration.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param lstash_tags Arbitrary tags for your events.
 #  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
 #
-# @param lstash_tags [Array] Arbitrary tags for your events.
-#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-syslog.html
+# @param lstash_type Type field to be added to all syslog events.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
-# @param trusted_nets [Array(Net Address)] An array of networks that you trust
-#   to connect to your server.
+# @param daemon_port The port that logstash itself should listen on.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
-# @param daemon_port [Port] The port that logstash itself should listen on.
+# @param proxy_protocol Whether to support proxy protocol, v1.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param ssl_verify Verify the SSL certificate of senders.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param lstash_tls_cert The SSL certificate to use for the TLS
+#   listener.
+#
+# @param lstash_tls_key The SSL key to use for the TLS listener.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
+#
+# @param lstash_tls_cacerts The file the contains the CA certificates.
+#  @see https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html
 #
 # @author Ralph Wright <rwright@onyxpoint.com>
 #
 class simp_logstash::input::tcp_syslog_tls (
   Optional[Hash]          $add_field          = {},
   Optional[String]        $codec              = undef,
+  Optional[Boolean]       $enable_metric      = undef,
   Optional[Simplib::IP]   $host               = '0.0.0.0',
+  Optional[String]        $id                 = 'simp_syslog_tls',
   Optional[Array[String]] $lstash_tags        = undef,
   String                  $lstash_type        = 'simp_syslog',
   Integer[0]              $order              = 50,
   Optional[String]        $content            = undef,
   Simplib::Port           $daemon_port        = 6514,
+  Optional[Boolean]       $proxy_protocol     = undef,
   Boolean                 $ssl_verify         = true,
   Stdlib::Absolutepath    $lstash_tls_cert    = $::simp_logstash::app_pki_cert,
   Stdlib::Absolutepath    $lstash_tls_key     = $::simp_logstash::app_pki_key,
@@ -82,8 +103,12 @@ class simp_logstash::input::tcp_syslog_tls (
     notify  => Class['logstash::service']
   }
 
-  iptables::listen::tcp_stateful { "allow_${_component_name}":
-    trusted_nets => $::simp_logstash::trusted_nets,
-    dports       => $daemon_port
+  if $::simp_logstash::firewall {
+    include '::iptables'
+
+    iptables::listen::tcp_stateful { "allow_${_component_name}":
+      trusted_nets => $::simp_logstash::trusted_nets,
+      dports       => $daemon_port
+    }
   }
 }

--- a/manifests/optimize.pp
+++ b/manifests/optimize.pp
@@ -1,26 +1,22 @@
-# Sets up a cron job to optimize your ElasticSearch indices on a regular basis
-# using elasticsearch-curator.
+# Sets up a cron job to optimize your Elasticsearch indices on a regular basis
+# using elasticsearch-curator. This optimization merges Elasticsearch log
+# segments to conserve storage space and speed up cluster recovery after
+# Elasticsearch restart.
 #
-# @param ensure Whether to add, or delete, the index job.
-#   Allowed Values: *present*, absent
+# In a SIMP environment, this should be installed on a Elasticsearch
+# host and then configured to use the local, unencrypted connection to
+# Elasticsearch.
 #
-# @param host The host upon which to operate. Ideally, you will
-#   position this job locally but it will work over thet network just as well
-#   provided your access controls allow it.
+# @param ensure Whether to add, or delete, the index optimization job.
 #
-# @param optimize_days The number of days to keep within
-#   ElasticSearch. Mutually exclusive with optimize_hours.
-#
-# @param optimize_hours The number of hours to keep within
-#   ElasticSearch. Mutually exclusive with optimize_days.
+# @param host The host upon which to operate.  Default is set for the
+#   local unencrypted connection to Elasticsearch.
 #
 # @param prefix The prefix to use to identify relevant logs. This is
 #   a match so 'foo' will match 'foo', 'foosball', and 'foot'.
 #
-# @param port The port to which to connect. Since this is SIMP
-#   tailored, we use our local unencrypted default.
-#
-# @param separator The index separator.
+# @param port The port to which to connect.  Default is set for the
+#   local unencrypted connection to Elasticsearch.
 #
 # @param es_timeout The timeout, in seconds, to wait for a response
 #   from Elasticsearch.
@@ -31,57 +27,45 @@
 # @param log_file The log file to which to print curator
 #   output.
 #
-# @param cron_hour The hour at which to run the index cleanup.
+# @param cron_hour The hour at which to run the index optimization.
 #
 # @param cron_minute The minute at which to run the index
-#   cleanup.
+#   optimization.
 #
 # @param cron_month The month within which to run the index
-#   cleanup.
+#   optimization.
 #
 # @param cron_monthday The day of the month upon which to run
-#   the index cleanup.
+#   the index optimization.
 #
 # @param cron_weekday The day of the week upon which to run
-#   the index cleanup.
+#   the index optimization.
 #
 class simp_logstash::optimize (
   Enum['present','absent']          $ensure           = 'present',
   Simplib::Host                     $host             = '127.0.0.1',
-  Optional[Integer[0]]              $optimize_days    = '2',
-  Optional[Integer[0]]              $optimize_hours   = '',
   String                            $prefix           = 'logstash-',
-  Simplib::Port                     $port             = '9199',
-  String                            $separator        = '.',
-  Integer[0]                        $es_timeout       = '21600',
-  Integer[0]                        $max_num_segments = '2',
+  Simplib::Port                     $port             = 9199,
+  Integer[0]                        $es_timeout       = 21600,
+  Integer[1]                        $max_num_segments = 2,
   Stdlib::Absolutepath              $log_file         = '/var/log/logstash/curator_optimize.log',
-  Variant[Enum['*'],Integer[0,23]]  $cron_hour        = '3',
-  Variant[Enum['*'],Integer[0,59]]  $cron_minute      = '15',
+  Variant[Enum['*'],Integer[0,23]]  $cron_hour        = 3,
+  Variant[Enum['*'],Integer[0,59]]  $cron_minute      = 15,
   Variant[Enum['*'],Integer[1,12]]  $cron_month       = '*',
   Variant[Enum['*'],Integer[1,31]]  $cron_monthday    = '*',
   Variant[Enum['*'],Integer[0,7]]   $cron_weekday     = '*'
 ) {
 
-  if defined('$::simp_logstash::auto_optimize') and getvar('::simp_logstash::auto_optimize') {
 
-    if size(reject([$optimize_days, $optimize_hours],'^\s*$')) > 1 {
-      fail('You may only specify one of $optimize_days or $optimize_hours')
-    }
+  if ($ensure == 'present') {
+    $_prefix_filter = "{\"filtertype\":\"pattern\",\"kind\":\"prefix\",\"value\":\"${prefix}\"}"
+    $_filter_list = "[${_prefix_filter}]"
 
-    if !empty($optimize_hours) {
-      $_limit = "-T hours --older-than ${optimize_hours}"
-    }
-    elsif !empty($optimize_days) {
-      $_limit = "-T days --older-than ${optimize_days}"
-    }
-    else {
-      fail('You must specify one of $optimize_days or $optimize_hours')
-    }
+    include '::simp_logstash::curator'
 
     cron { 'logstash_index_optimize':
       ensure   => $ensure,
-      command  => "/usr/bin/curator --host ${host} --port ${port} -t ${es_timeout} optimize -p '${prefix}' -s '${separator}' ${_limit} --max_num_segments ${max_num_segments} >> ${log_file} 2>&1",
+      command  => "/usr/bin/curator_cli --host ${host} --port ${port} --timeout ${es_timeout} --logfile ${log_file} forcemerge --max_num_segments ${max_num_segments} --ignore_empty_list --filter_list '${_filter_list}'",
       hour     => $cron_hour,
       minute   => $cron_minute,
       month    => $cron_month,

--- a/manifests/optimize.pp
+++ b/manifests/optimize.pp
@@ -1,48 +1,48 @@
 # Sets up a cron job to optimize your ElasticSearch indices on a regular basis
 # using elasticsearch-curator.
 #
-# @param ensure [String] Whether to add, or delete, the index job.
+# @param ensure Whether to add, or delete, the index job.
 #   Allowed Values: *present*, absent
 #
-# @param host [Hostname] The host upon which to operate. Ideally, you will
+# @param host The host upon which to operate. Ideally, you will
 #   position this job locally but it will work over thet network just as well
 #   provided your access controls allow it.
 #
-# @param optimize_days [Integer] The number of days to keep within
+# @param optimize_days The number of days to keep within
 #   ElasticSearch. Mutually exclusive with optimize_hours.
 #
-# @param optimize_hours [Integer] The number of hours to keep within
+# @param optimize_hours The number of hours to keep within
 #   ElasticSearch. Mutually exclusive with optimize_days.
 #
-# @param prefix [String] The prefix to use to identify relevant logs. This is
+# @param prefix The prefix to use to identify relevant logs. This is
 #   a match so 'foo' will match 'foo', 'foosball', and 'foot'.
 #
-# @param port* [Port] The port to which to connect. Since this is SIMP
+# @param port The port to which to connect. Since this is SIMP
 #   tailored, we use our local unencrypted default.
 #
-# @param separator [Char] The index separator.
+# @param separator The index separator.
 #
-# @param es_timeout [Integer] The timeout, in seconds, to wait for a response
+# @param es_timeout The timeout, in seconds, to wait for a response
 #   from Elasticsearch.
 #
-# @param max_num_segments [Integer] Optimize segment count to $max_num_segments
+# @param max_num_segments Optimize segment count to $max_num_segments
 #   per shard.
 #
-# @param log_file [Absolute Path] The log file to which to print curator
+# @param log_file The log file to which to print curator
 #   output.
 #
-# @param cron_hour [Integer or '*'] The hour at which to run the index cleanup.
+# @param cron_hour The hour at which to run the index cleanup.
 #
-# @param cron_minute [Integer or '*'] The minute at which to run the index
+# @param cron_minute The minute at which to run the index
 #   cleanup.
 #
-# @param cron_month [Integer or '*'] The month within which to run the index
+# @param cron_month The month within which to run the index
 #   cleanup.
 #
-# @param cron_monthday [Integer or '*'] The day of the month upon which to run
+# @param cron_monthday The day of the month upon which to run
 #   the index cleanup.
 #
-# @param cron_weekday [Integer or '*'] The day of the week upon which to run
+# @param cron_weekday The day of the week upon which to run
 #   the index cleanup.
 #
 class simp_logstash::optimize (

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -8,7 +8,6 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 define simp_logstash::output {
   include "::simp_logstash::output::${name}"
 }

--- a/manifests/output/elasticsearch.pp
+++ b/manifests/output/elasticsearch.pp
@@ -4,98 +4,157 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param action [String] The Elasticsearch action to perform.
+# @param absolute_healthcheck_path When a healthcheck_path config is provided,
+#   this additional flag can be used to specify whether the healthcheck_path
+#   is appended to the existing path (default) or is treated as the absolute
+#   URL path.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param action The Elasticsearch action to perform.
 #   Allowed Values: index, delete, create, update
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param codec [String] The codec used for output data.
+# @param codec The codec used for output data.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param doc_as_upsert [Boolean] Create a new document with source if
+# @param doc_as_upsert Create a new document with source if
 #   `document_id` doesn't exist in Elasticsearch.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param document_id [String] The document ID for the index.
+# @param document_id The document ID for the index.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param document_type [String] The document type to write events to.
+# @param document_type The document type to write events to.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @parm flush_size [Integer] Maximum sized bulk request.
+# @param enable_metric Whether to enable metric logging for this plugin
+#   instance.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param host [Net Address] The host of the remote instance.
+# @param failure_type_logging_whitelist Elasticsearch errors you don't want
+#   to log.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param flush_size Maximum sized bulk request.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param healthcheck_path When a backend is marked down a HEAD request will be
+#   sent to this path in the background to see if it has come back again
+#   before it is once again eligible to service requests.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param host The host of the remote instance.
 #   @note It is highly recommended that you couple an Elasticsearch ingest node
 #   with the LogStash server itself.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param port [Port] The port on the remote instance to which to connect.
+# @param port The port on the remote instance to which to connect.
 #
-# @param idle_flush_time [Integer] The amount of time since last flush before a
+# @param id Unique ID for this output plugin configuration.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param idle_flush_time The amount of time since last flush before a
 #   flush is forced.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param index [String] The index to write events to.
+# @param index The index to write events to.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param manage_template [Boolean] If set, apply a default mapping template
+# @param manage_template If set, apply a default mapping template
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param parent [String] The ID of the associated parent document.
+# @param parameters Pass a set of key value pairs as the URL query string.
+#   This query string is added to the host listed in the host configuration.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param path [Absolute Path] HTTP path at which the Elasticsearch server lives.
+# @param parent The ID of the associated parent document.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param retry_max_interval [Integer] Set max interval between bulk retries.
+# @param path HTTP path at which the Elasticsearch server lives.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param routing [String] A routing override to be applieid to all events.
+# @param pipeline Which ingest pipeline you wish to execute for an event.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param script [String] Set script name for scripted update module.
+# @param pool_max Maximum number of open connections the output will create.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param script_lang [String] Set the language of the used script.
+# @param pool_max_per_route Maximum number of open connections per endpoint
+#   the output will create.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param script_type [String] Define the type of script referenced by `$script`.
+# @param resurrect_delay How frequently, in seconds, to wait between
+#   resurrection attempts.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param retry_initial_interval Initial interval in seconds between bulk
+#   retries.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param retry_max_interval Set max interval between bulk retries.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param retry_on_conflict Number of times Elasticsearch should internally
+#   retry an update/upserted document.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param routing A routing override to be applieid to all events.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param script Set script name for scripted update module.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param script_lang Set the language of the used script.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param script_type Define the type of script referenced by `$script`.
 #   Allowed Values: 'inline', 'indexed', 'file'
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param script_var_name [String] Variable name passed to script.
+# @param script_var_name Variable name passed to script.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param scripted_upsert [Boolean] If set, `$script` is in charge of creating
+# @param scripted_upsert If set, `$script` is in charge of creating
 #   non-existent document
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param template [Absolute Path] The path to your own template.
+# @param template The path to your own template.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param template_name [String] The name of the template in Elasticsearch.
+# @param template_name The name of the template in Elasticsearch.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param template_overwrite [Boolean] If set, overwrite the indicated template
+# @param template_overwrite If set, overwrite the indicated template
 #   in ES with either the one dicated by `template` or the included one.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param timeout [Integer] Timeout for network operations.
+# @param timeout Timeout for network operations.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param upsert [String] Upsert content for update mode.
+# @param upsert Upsert content for update mode.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param workers [Integer] Number of workers to use for this output.
+# @param validate_after_inactivity How long to wait before checking if
+#   the connection is stale before executing a request on a connection
+#   using keepalive.
 #   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 #
-# @param order [Integer] The relative order within the configuration group. If
+# @param version Version to use for indexing.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param version_type version_type to use for indexing.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param workers Number of workers to use for this output.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+#
+# @param order The relative order within the configuration group. If
 #   omitted, the entries will fall in alphabetical order.
 #
-# @param content [String] The content that you wish to have in your filter. If
+# @param content The content that you wish to have in your filter. If
 #   set, this will override *all* template contents.
 #
-# @param stunnel_port [Port] The port on the local host to which to connect to
+# @param stunnel_port The port on the local host to which to connect to
 #   use the stunnel connection to the remote ES system. This is not required if
 #   you are connecting to an ES server on the local system.
 #
@@ -116,7 +175,7 @@
 #       * level 4 - Ignore CA chain and only verify peer certificate.                                    
 #       * default - No verify
 #
-# @param stunnel_elasticsearch [Boolean] If set, use a stunnel connection to
+# @param stunnel_elasticsearch If set, use a stunnel connection to
 #   connect to ES. This is necessary if you are using ES behind an HTTPS proxy.
 #   If you're using ES on the same host, and using the `::simp_elasticsearch`
 #   class (the default), then the system will auto-adjust to ignore this
@@ -124,26 +183,37 @@
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::output::elasticsearch (
-  Optional[Array[Enum['index','delete','create']]]  $action                = undef,
+  Optional[Boolean]                                 $absolute_healthcheck_path = undef,
+  Optional[Enum['index','delete','create']]         $action                = undef,
   Optional[String]                                  $codec                 = undef,
   Optional[Boolean]                                 $doc_as_upsert         = undef,
   Optional[String]                                  $document_id           = undef,
   Optional[String]                                  $document_type         = undef,
+  Optional[Boolean]                                 $enable_metric         = undef,
+  Optional[Array[String]]                           $failure_type_logging_whitelist = undef,
   Optional[Integer[0]]                              $flush_size            = undef,
+  Optional[Stdlib::Absolutepath]                    $healthcheck_path      = undef,
   Simplib::Host                                     $host                  = 'localhost',
+  Optional[String]                                  $id                    = 'simp_elasticsearch',
   Simplib::Port                                     $port                  = 9199,
   Optional[Integer[0]]                              $idle_flush_time       = undef,
   Optional[String]                                  $index                 = undef,
   Optional[Boolean]                                 $manage_template       = undef,
+  Optional[Hash]                                    $parameters            = undef,
   Optional[String]                                  $parent                = undef,
   Optional[Stdlib::Absolutepath]                    $path                  = undef,
+  Optional[String]                                  $pipeline              = undef,
+  Optional[Integer[1]]                              $pool_max              = undef,
+  Optional[Integer[1]]                              $pool_max_per_route    = undef,
+  Optional[Integer[0]]                              $resurrect_delay       = undef,
+  Optional[Integer[0]]                              $retry_initial_interval = undef,
   Optional[Integer[0]]                              $retry_max_interval    = undef,
+  Optional[Integer[0]]                              $retry_on_conflict     = undef,
   Optional[String]                                  $routing               = undef,
   Optional[String]                                  $script                = undef,
   Optional[String]                                  $script_lang           = undef,
-  Optional[Array[Enum['inline','idexed','file']]]   $script_type           = undef,
+  Optional[Array[Enum['inline','indexed','file']]]  $script_type           = undef,
   Optional[String]                                  $script_var_name       = undef,
   Optional[Boolean]                                 $scripted_upsert       = undef,
   Optional[Stdlib::Absolutepath]                    $template              = undef,
@@ -151,6 +221,10 @@ class simp_logstash::output::elasticsearch (
   Optional[Boolean]                                 $template_overwrite    = undef,
   Optional[Integer[0]]                              $timeout               = undef,
   Optional[String]                                  $upsert                = undef,
+  Optional[Integer[0]]                              $validate_after_inactivity = undef,
+  Optional[String]                                  $version               = undef,
+  Optional[Enum['internal','external',
+    'external_gt', 'external_gte', 'force']]        $version_type          = undef,
   Optional[Integer[0]]                              $workers               = undef,
   Integer[0]                                        $order                 = 50,
   Optional[String]                                  $content               = undef,
@@ -162,14 +236,14 @@ class simp_logstash::output::elasticsearch (
   $_is_local = host_is_me($host)
 
   if $stunnel_elasticsearch {
-    include '::stunnel'
-
     $_host = '127.0.0.1'
 
     if $_is_local {
       $_port = $port
     }
     else {
+      include '::stunnel'
+
       stunnel::connection { 'logstash_elasticsearch':
         client  => true,
         connect => ["${host}:${stunnel_port}"],

--- a/manifests/output/file.pp
+++ b/manifests/output/file.pp
@@ -4,39 +4,62 @@
 # they remain separate in the event that variables need to be added in the
 # future for ERB processing.
 #
-# @param path [Absolute_Path] The destination for the file output.
+# @param path The destination for the file output.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param codec [String] The codec used for output data.
-#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
+# @param codec The codec used for output data.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param create_if_deleted [Boolean] Create the target file if necessary.
+# @param create_if_deleted Create the target file if necessary.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param dir_mode [Integer] The mode for created directories.
+# @param dir_mode The mode for created directories.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param file_mode [Integer] The mode for created files.
+# @param enable_metric Whether to enable metric logging for this plugin
+#   instance.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param filename_failure [String] If the generated path is invalid, save
+# @param file_mode The mode for created files.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
+#
+# @param filename_failure If the generated path is invalid, save
 #   output to this filename instead.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param flush_interval [Integer] Seconds in which to flush to log files.
+# @param flush_interval Seconds in which to flush to log files.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param gzip [Boolean] Gzip the output stream before writing to disk.
+# @param gzip Gzip the output stream before writing to disk.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
 #
-# @param workers [Integer] The number of workers to use for this output.
+# @param id Unique ID for this output plugin configuration.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
+#
+# @param workers The number of workers to use for this output.
+#   @see https://www.elastic.co/guide/en/logstash/current/plugins-outputs-file.html
+#
+# @param order The relative order within the configuration group. If
+#   omitted, the entries will fall in alphabetical order.
+#
+# @param content The content that you wish to have in your filter. If
+#   set, this will override *all* template contents.
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-# @copyright 2016 Onyx Point, Inc.
 class simp_logstash::output::file (
   Stdlib::Absolutepath  $path              = '/var/log/logstash/file_output.log',
   Optional[String]      $codec             = undef,
   Optional[Boolean]     $create_if_deleted = undef,
   Optional[Integer[0]]  $dir_mode          = undef,
+  Optional[Boolean]     $enable_metric     = undef,
   Optional[Integer[0]]  $file_mode         = undef,
   Optional[String]      $filename_failure  = undef,
   Optional[Integer[0]]  $flush_interval    = undef,
   Optional[Boolean]     $gzip              = undef,
+  Optional[String]      $id                = 'simp_file',
   Optional[String]      $content           = undef,
+  Integer[0]            $order             = 30,
   Optional[Integer[0]]  $workers           = undef
 ) {
 
@@ -54,7 +77,7 @@ class simp_logstash::output::file (
     $_content = $content
   }
 
-  file { "${::simp_logstash::config_prefix}-${_group_order}_${_group}-${_group_order}-${_component_name}${::simp_logstash::config_suffix}":
+  file { "${::simp_logstash::config_prefix}-${_group_order}_${_group}-${order}-${_component_name}${::simp_logstash::config_suffix}":
     ensure  => 'file',
     owner   => 'root',
     group   => $::logstash::logstash_group,

--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,8 @@
   ],
   "dependencies": [
     {
-      "name": "elasticsearch/logstash",
-      "version_requirement": ">= 5.1.0 < 6.0.0"
+      "name": "elastic/logstash",
+      "version_requirement": ">= 5.2.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/java",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_logstash",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-logstash",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "elasticsearch/logstash",
-      "version_requirement": ">= 5.0.3 < 6.0.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/java",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,11 +11,11 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       logstash:
-        #baseurl: 'http://10.255.0.1:8888/'
-        baseurl: 'http://packages.elastic.co/logstash/2.3/centos'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/7/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
 
@@ -29,7 +29,7 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/7/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
 
@@ -42,11 +42,11 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       logstash:
-        baseurl: 'http://packages.elastic.co/logstash/2.3/centos'
-        #baseurl: 'http://10.255.0.1:8888/'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/6/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
 
@@ -60,7 +60,7 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/6/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
 

--- a/spec/acceptance/suites/default/01_client_server_spec.rb
+++ b/spec/acceptance/suites/default/01_client_server_spec.rb
@@ -2,11 +2,12 @@
 
 require 'spec_helper_acceptance'
 
-test_name 'rsyslog clients -> 1 server without TLS'
+test_name 'rsyslog clients -> 1 logstash server without TLS'
 
-describe 'rsyslog client -> 1 server without TLS' do
+describe 'rsyslog client -> 1 logstash server without TLS' do
   clients = hosts_with_role( hosts, 'client' )
   servers = hosts_with_role( hosts, 'logstash_server' )
+  let(:remote_log)  { '/var/log/logstash/file_output.log' }
 
   clients.each do |client|
     servers.each do |server|
@@ -23,7 +24,7 @@ describe 'rsyslog client -> 1 server without TLS' do
           }
         EOS
 
-      context 'client -> 1 server without TLS' do
+      context "client #{client}-> server #{server} without TLS" do
         it 'should configure client without errors' do
           apply_manifest_on(client, client_manifest, :catch_failures => true)
         end
@@ -33,11 +34,108 @@ describe 'rsyslog client -> 1 server without TLS' do
         end
 
         it 'should successfully send log messages' do
-          on client, 'logger -t FOO 01-TEST-WITHOUT-TLS'
-          sleep(5)
-          remote_log = '/var/log/logstash/file_output.log'
-          on server, "test -f #{remote_log}"
-          on server, "grep 01-TEST-WITHOUT-TLS #{remote_log}"
+          log_msg = "01-TEST-WITHOUT-TLS-#{client}"
+          on client, "logger -t FOO #{log_msg}"
+          wait_for_log_message(server, remote_log, log_msg)
+        end
+
+        it 'should filter yum messages' do
+          on server, "rm -f #{remote_log}"  # start with a clean log
+          client.install_package('vim-X11')
+
+          wait_for_log_message(server, remote_log, 'vim-X11')
+          result = on(server, "grep 'vim-X11' #{remote_log}")
+          log_lines = result.stdout.split("\n")
+          log_lines.delete_if { |line| !line.include?('"program":"yum"') }
+          fail("yum line match failed") if log_lines.empty?
+          log_line = log_lines.last
+          expect(log_line).to match(/"package":".+:vim-X11/)
+          expect(log_line).to match(/"yum_action":"Installed"/)
+          on(client, 'yum erase -y vim-X11') # prep for next yum test on this client
+        end
+
+        it 'should filter valid sshd login messages ' do
+          # beaker opens and maintains ssh sessions into the VMs for
+          # host operations. So need to open up a new ssh connection for this test.
+          # host_hash[:ip] is the IP address of the host normally used for
+          #   ssh access via vagrant user
+          # host_hash[:ssh] has the ssh config setup required to get into the host
+          #   behind the NAT
+          Net::SSH.start(client.host_hash[:ip], 'vagrant', client.host_hash[:ssh]) do |ssh|
+            puts ssh.exec!('find')
+          end
+          result = on(server, "grep 'Accepted publickey for' #{remote_log}")
+          log_line = result.stdout.split("\n").last
+          match = log_line.match(/Accepted publickey for vagrant from (\S+) port (\S+) /)
+          fail("sshd line match failed: #{log_line}") if match.nil?
+          expect(log_line).to match(/"ssh_status":"Accepted"/)
+          expect(log_line).to match(/"ssh_auth_type":"publickey"/)
+          expect(log_line).to match(/"user":"vagrant"/)
+          expect(log_line).to match(/"src_ip":"#{match[1]}"/)
+          expect(log_line).to match(/"src_port":"#{match[2]}"/)
+          expect(log_line).to match(/"src_protocol":"ssh2"/)
+        end
+
+        it 'should filter invalid sshd login messages' do
+          begin
+            Net::SSH.start(client.host_hash[:ip], 'bad_guy', client.host_hash[:ssh])
+          rescue Net::SSH::AuthenticationFailed => e
+          end
+          wait_for_log_message(server, remote_log, 'user bad_guy from')
+          result = on(server, "grep 'user bad_guy from' #{remote_log}")
+          log_line = result.stdout.split("\n").last
+          ip = log_line.match(/from ([0-9.]+)"/)[1]
+          expect(log_line).to match(/"user":"bad_guy"/)
+          expect(log_line).to match(/"src_ip":"#{ip}"/)
+        end
+
+        # The proposed tests that follow require setup that may be better
+        # suited to an integration test with a real SIMP server and clients.
+        # One of the tests was mocked with example messages, but that test
+        # won't tell us when our filter has been broken by a change in
+        # an application's log messages that we are parsing.
+        it 'should filter audispd log messages'
+        it 'should filter httpd log messages'
+        it 'should filter puppet agent log messages'
+        it 'should filter puppet server log messages'
+        it 'should filter slapd audit log messages'
+
+        it 'should filter sudosh log messages' do
+          # FIXME This simulates successful sudosh messages with message content
+          # taken from an el7 server.  To really test this, need to install
+          # sudosh puppet module, configure a user to have sudosh privileges
+          # and then execute 'sudo sudosh' by that user.  Also need to execute
+          # 'sudo sudosh' by an unauthorized user to see if that also triggers
+          # an error message that get filtered.
+          messages = [
+            'starting session for user1 as root, session id 1494001737, tty /dev/pts/4, shell /bin/bash',
+            '[1494001737]: msg: user1:root: #033]0;root@blade08:~#007#033[?1034h[root@blade08 ~]# ls#015#012anaconda-ks.cfg  puppet.bootstrap.log  #033[0m#033[38;5;34msimp6.sh#033[0m#015#012#033]0;root@blade08:~#007[root@blade08 ~]# which puppet#015#012/opt/puppetlabs/bin/puppet#015#012#033]0;root@blade08:~#007[root@blade08 ~]# exit#015#012logout#015',
+            '[1494001737]: time: user1:root: 0.368416 19#012:0.101542 8#012:0.000358 18#012:1.603391 1#012:0.199875 1#012:0.175738 2#012:0.000184 67#012:0.002871 19#012:0.000577 18#012:11.996672 1#012:0.103868 1#012:0.095862 1#012:0.224277 1#012:0.120101 1#012:0.119602 1#012:0.120125 1#012:0.079826 1#012:0.056011 1#012:0.208254 1#012:0.480061 1#012:0.120003 1#012:0.135900 2#012:0.000177 28#012:0.002864 19#012:0.000455 18#012:0.756906 1#012:0.199762 1#012:0.119835 1#012:0.280119 1#012:0.464102 2#012:0.000194 8#012:',
+            'stopping session for user1 as root, tty /dev/pts/4, shell /bin/bash'
+          ]
+          messages.each { |log_msg| on client, "logger -t sudosh '#{log_msg}'" }
+          wait_for_log_message(server, remote_log, 'stopping session for user1 as root')
+
+          # verify starting session message is filtered
+          result = on(server, "grep 'starting session for user1 as root' #{remote_log}")
+          log_line = result.stdout.split("\n").last
+          expect(log_line).to match(/"user":"user1"/)
+          expect(log_line).to match(/"sudosh_session_id":"1494001737"/)
+
+          # verify messages containing session id are filtered
+          result = on(server, "grep '\\[1494001737\\]: msg: ' #{remote_log}")
+          log_line = result.stdout.split("\n").last
+          expect(log_line).to match(/"sudosh_session_id":"1494001737"/)
+          expect(log_line).to match(/"sudosh_type":"msg"/)
+          expect(log_line).to match(/"user":"user1"/)
+          expect(log_line).to match(Regexp.escape('"sudosh_message":"#033]0;root@blade08:~#007#033[?1034h[root@blade08 ~]# ls#015#012anaconda-ks.cfg  puppet.bootstrap.log  #033[0m#033[38;5;34msimp6.sh#033[0m#015#012#033]0;root@blade08:~#007[root@blade08 ~]# which puppet#015#012/opt/puppetlabs/bin/puppet#015#012#033]0;root@blade08:~#007[root@blade08 ~]# exit#015#012logout#015'))
+
+          result = on(server, "grep '\\[1494001737\\]: time: ' #{remote_log}")
+          log_line = result.stdout.split("\n").last
+          expect(log_line).to match(/"sudosh_session_id":"1494001737"/)
+          expect(log_line).to match(/"sudosh_type":"time"/)
+          expect(log_line).to match(/"user":"user1"/)
+          expect(log_line).to match(Regexp.escape('0.368416 19#012:0.101542 8#012:0.000358 18#012:1.603391 1#012:0.199875 1#012:0.175738 2#012:0.000184 67#012:0.002871 19#012:0.000577 18#012:11.996672 1#012:0.103868 1#012:0.095862 1#012:0.224277 1#012:0.120101 1#012:0.119602 1#012:0.120125 1#012:0.079826 1#012:0.056011 1#012:0.208254 1#012:0.480061 1#012:0.120003 1#012:0.135900 2#012:0.000177 28#012:0.002864 19#012:0.000455 18#012:0.756906 1#012:0.199762 1#012:0.119835 1#012:0.280119 1#012:0.464102 2#012:0.000194 8#012:'))
         end
       end
     end

--- a/spec/acceptance/suites/default/02_client_server_with_tls_spec.rb
+++ b/spec/acceptance/suites/default/02_client_server_with_tls_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper_acceptance'
 
-test_name 'rsyslog clients -> 1 server with TLS'
+test_name 'rsyslog clients -> 1 logstash server with TLS'
 
-describe 'rsyslog client -> 1 server with TLS' do
+describe 'rsyslog client -> 1 logstash server with TLS' do
   clients = hosts_with_role( hosts, 'client' )
   servers = hosts_with_role( hosts, 'logstash_server' )
 
@@ -22,7 +22,7 @@ describe 'rsyslog client -> 1 server with TLS' do
           }
         EOS
 
-      context 'client -> 1 server using TLS' do
+      context "client #{client}-> logstash server #{server} using TLS" do
         it 'should configure client without errors' do
           apply_manifest_on(client, client_manifest, :catch_failures => true)
         end
@@ -32,11 +32,10 @@ describe 'rsyslog client -> 1 server with TLS' do
         end
 
         it 'should successfully send log messages' do
-          on client, 'logger -t FOO 02-TEST-WITH-TLS'
-          sleep(15)
+          log_msg = "02-TEST-WITH-TLS-#{client}"
+          on client, "logger -t FOO #{log_msg}"
           remote_log = '/var/log/logstash/file_output.log'
-          on server, "test -f #{remote_log}"
-          on server, "grep 02-TEST-WITH-TLS #{remote_log}"
+          wait_for_log_message(server, remote_log, log_msg)
         end
       end
     end

--- a/spec/acceptance/suites/default/03_client_server_failover_spec.rb
+++ b/spec/acceptance/suites/default/03_client_server_failover_spec.rb
@@ -5,9 +5,9 @@
 
 require 'spec_helper_acceptance'
 
-test_name 'rsyslog client -> 2 servers without TLS with failover'
+test_name 'rsyslog client -> 2 logstash servers without TLS with failover'
 
-describe 'rsyslog client -> 2 servers without TLS with failover' do
+describe 'rsyslog client -> 2 logstash servers without TLS with failover' do
   before(:all) do
     # Ensure that our test doesn't match messages from other tests
     sleep(1)
@@ -22,6 +22,26 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
   if primary_server == failover_server
     fail('You must define more than one server!')
   end
+
+  # 'puppet resource service' has to be told the service provider
+  # is upstart.
+  let(:primary_server_service_provider) {
+    if primary_server.name == 'el6-server'
+      provider = 'provider=upstart'
+    else
+      provider = ''
+    end
+    provider
+  }
+
+  let(:failover_server_service_provider) {
+    if failover_server.name == 'el6-server'
+      provider = 'provider=upstart'
+    else
+      provider = ''
+    end
+    provider
+  }
 
   clients.each do |client|
     let(:client_manifest) {
@@ -40,7 +60,7 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
       EOS
     }
 
-    context 'client setup' do
+    context "client #{client} with primary syslog server #{primary_server} and failover server #{failover_server}" do
       let(:remote_log) { '/var/log/logstash/file_output.log' }
 
       it 'should configure client without errors' do
@@ -50,34 +70,29 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
       it 'should configure client idempotently' do
         apply_manifest_on(client, client_manifest, :catch_changes => true)
 
-        # Ensure that the server on the primary is running for the intitial
+        # Ensure that the server on the primary is running for the initial
         # tests
-        on(primary_server, 'puppet resource service logstash ensure=running')
+        on(primary_server, "puppet resource service logstash ensure=running #{primary_server_service_provider}")
 
         # Ensure the failover server restarts to force any connections back to
         # the primary for other hosts
-        on(failover_server, 'puppet resource service logstash ensure=stopped')
+        on(failover_server, "puppet resource service logstash ensure=stopped #{failover_server_service_provider}")
         sleep(2)
-        on(failover_server, 'puppet resource service logstash ensure=running')
+        on(failover_server, "puppet resource service logstash ensure=running #{failover_server_service_provider}")
 
         # Give it a bit to start
         sleep(60)
       end
 
       it 'should successfully send log messages to the primary server but not the failover server' do
-        msg = "01-TEST-#{@msg_uuid}-#{client}"
-
-        on(client, "logger -t FOO #{msg}")
-        sleep(5)
-
-        on(primary_server, "test -f #{remote_log}")
-        on(primary_server, "grep #{msg} #{remote_log}")
-
-        on(failover_server, "(! grep #{msg} #{remote_log} )")
+        log_msg = "01-TEST-#{@msg_uuid}-#{client}"
+        on(client, "logger -t FOO #{log_msg}")
+        wait_for_log_message(primary_server, remote_log, log_msg)
+        on(failover_server, "(! grep #{log_msg} #{remote_log} )")
       end
 
       it 'should successfully failover' do
-        on(primary_server, 'puppet resource service logstash ensure=stopped')
+        on(primary_server, "puppet resource service logstash ensure=stopped #{primary_server_service_provider}")
         # Give it a bit to die
         sleep(5)
 
@@ -88,9 +103,9 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
         end
 
         # Validate Failover
-        on(failover_server, "grep 01-TEST-12-#{@msg_uuid}-MSG-#{client} #{remote_log}")
-        sleep(1)
-        on(failover_server, "grep 01-TEST-19-#{@msg_uuid}-MSG-#{client} #{remote_log}")
+        # TODO What about 01-TEST-11  and 01-TEST-20 messages?
+        wait_for_log_message(failover_server, remote_log, "01-TEST-12-#{@msg_uuid}-MSG-#{client}")
+        wait_for_log_message(failover_server, remote_log, "01-TEST-19-#{@msg_uuid}-MSG-#{client}")
 
         on(primary_server, "(! grep 01-TEST-12-#{@msg_uuid}-MSG-#{client} #{remote_log} )")
         on(primary_server, "(! grep 01-TEST-19-#{@msg_uuid}-MSG-#{client} #{remote_log} )")

--- a/spec/acceptance/suites/default/04_client_server_failover_with_tls_spec.rb
+++ b/spec/acceptance/suites/default/04_client_server_failover_with_tls_spec.rb
@@ -5,9 +5,9 @@
 
 require 'spec_helper_acceptance'
 
-test_name 'rsyslog client -> 2 servers without TLS with failover'
+test_name 'rsyslog client -> 2 logstash servers with TLS with failover'
 
-describe 'rsyslog client -> 2 servers without TLS with failover' do
+describe 'rsyslog client -> 2 logstash servers with TLS with failover' do
   before(:all) do
     # Ensure that our test doesn't match messages from other tests
     sleep(1)
@@ -22,6 +22,26 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
   if primary_server == failover_server
     fail('You must define more than one server!')
   end
+
+  # 'puppet resource service' has to be told the service provider
+  # is upstart.
+  let(:primary_server_service_provider) {
+    if primary_server.name == 'el6-server'
+      provider = 'provider=upstart'
+    else
+      provider = ''
+    end
+    provider
+  }
+
+  let(:failover_server_service_provider) {
+    if failover_server.name == 'el6-server'
+      provider = 'provider=upstart'
+    else
+      provider = ''
+    end
+    provider
+  }
 
   clients.each do |client|
     let(:client_manifest) {
@@ -41,7 +61,7 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
       EOS
     }
 
-    context 'client setup' do
+    context "client #{client} with primary syslog server #{primary_server} and failover server #{failover_server}" do
       let(:remote_log) { '/var/log/logstash/file_output.log' }
 
       it 'should configure client without errors' do
@@ -51,25 +71,26 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
       it 'should configure client idempotently' do
         apply_manifest_on(client, client_manifest, :catch_changes => true)
 
-        # Ensure that the server on the primary is running for the intitial
+        # Ensure that the server on the primary is running for the initial
         # tests
-        on(primary_server, 'puppet resource service logstash ensure=running')
+        on(primary_server, "puppet resource service logstash ensure=running #{primary_server_service_provider}")
 
         # Ensure the failover server restarts to force any connections back to
         # the primary for other hosts
-        on(failover_server, 'puppet resource service logstash ensure=stopped')
+        on(failover_server, "puppet resource service logstash ensure=stopped #{failover_server_service_provider}")
         sleep(20)
-        on(failover_server, 'puppet resource service logstash ensure=running')
+        on(failover_server, "puppet resource service logstash ensure=running #{failover_server_service_provider}")
 
         # Give it a bit to start
         sleep(60)
       end
 
+
       it 'should successfully send log messages to the primary server but not the failover server' do
         msg = "01-TEST-#{@msg_uuid}-#{client}"
 
         on(client, "logger -t FOO #{msg}")
-        sleep(5)
+        sleep(10)
 
         on(primary_server, "test -f #{remote_log}")
         on(primary_server, "grep #{msg} #{remote_log}")
@@ -81,7 +102,7 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
         # Unfortunately, rsyslog considers a successful TLS connection to be
         # all that it requires to bind to a system. As such, we have to stop
         # logstash
-        on(primary_server, 'puppet resource service logstash ensure=stopped')
+        on(primary_server, "puppet resource service logstash ensure=stopped #{primary_server_service_provider}")
 
         # Give it a bit to die
         sleep(25)
@@ -102,8 +123,8 @@ describe 'rsyslog client -> 2 servers without TLS with failover' do
         # For some reason, messages 11 and 12 never make it to the failover.
         # They also don't make it to the primary.  That should be addressed in the
         # rsyslog module.
-        on(failover_server, "grep 01-TEST-13-#{@msg_uuid}-MSG-#{client} #{remote_log}")
-        on(failover_server, "grep 01-TEST-19-#{@msg_uuid}-MSG-#{client} #{remote_log}")
+        wait_for_log_message(failover_server, remote_log, "01-TEST-13-#{@msg_uuid}-MSG-#{client}")
+        wait_for_log_message(failover_server, remote_log, "01-TEST-19-#{@msg_uuid}-MSG-#{client}")
 
         on(primary_server, "(! grep 01-TEST-13-#{@msg_uuid}-MSG-#{client} #{remote_log} )")
         on(primary_server, "(! grep 01-TEST-19-#{@msg_uuid}-MSG-#{client} #{remote_log} )")

--- a/spec/acceptance/suites/elasticsearch/metadata.yml
+++ b/spec/acceptance/suites/elasticsearch/metadata.yml
@@ -1,0 +1,2 @@
+---
+'default_run' : true

--- a/spec/acceptance/suites/elasticsearch/nodesets/default.yml
+++ b/spec/acceptance/suites/elasticsearch/nodesets/default.yml
@@ -11,11 +11,11 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       logstash:
-        #baseurl: 'http://10.255.0.1:8888/'
-        baseurl: 'http://packages.elastic.co/logstash/2.3/centos'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/7/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
 
@@ -27,18 +27,15 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: vagrant
-    simp_update_url : https://dl.bintray.com/simp/5.1.X
     yum_repos:
-      simp:
-        baseurl: https://dl.bintray.com/simp/5.1.X
-        gpgcheck: 0
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/7/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
       elasticsearch:
-        baseurl: 'https://packages.elastic.co/elasticsearch/2.x/centos'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
   el6-server:
     roles:
@@ -49,11 +46,11 @@ HOSTS:
     hypervisor: vagrant
     yum_repos:
       logstash:
-        baseurl: 'http://packages.elastic.co/logstash/2.3/centos'
-        #baseurl: 'http://10.255.0.1:8888/'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/6/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
 
@@ -65,18 +62,15 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: vagrant
-    simp_update_url : https://dl.bintray.com/simp/4.2.X
     yum_repos:
-      simp:
-        baseurl: https://dl.bintray.com/simp/4.2.X
-        gpgcheck: 0
       epel:
-        url: 'http://download.fedoraproject.org/pub/epel/6/$basearch'
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
       elasticsearch:
-        baseurl: 'https://packages.elastic.co/elasticsearch/2.x/centos'
-        gpgcheck: 0
+        baseurl:  https://artifacts.elastic.co/packages/5.x/yum
+        gpgkeys:
+          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
 CONFIG:
   log_level: verbose

--- a/spec/classes/clean_spec.rb
+++ b/spec/classes/clean_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe 'simp_logstash::clean' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with default parameters' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::clean') }
+
+        it { 
+          cmd = []
+          cmd << '/usr/bin/curator_cli' <<
+                '--host 127.0.0.1' <<
+                '--port 9199' <<
+                '--timeout 30' <<
+                '--logfile /var/log/logstash/curator_clean.log' <<
+                'delete_indices' <<
+                '--ignore_empty_list' <<
+                '--filter_list \'[{"filtertype":"age","source":"creation_date","direction":"older","unit":"days","unit_count":356},{"filtertype":"pattern","kind":"prefix","value":"logstash-"}]\''
+
+          is_expected.to create_cron('logstash_index_cleanup').with({
+            :ensure   => 'present',
+            :command  => cmd.join(' '),
+            :hour     => 1,
+            :minute   => 15,
+            :month    => '*',
+            :monthday => '*',
+            :weekday  => '*',
+            :require  => 'Class[Simp_logstash::Curator]'
+          }) 
+        }
+      end
+
+      context "ensure='absent'" do
+        let(:params) {{
+          :ensure => 'absent'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::clean') }
+        it { is_expected.to create_cron('logstash_index_cleanup').with({
+          :ensure => 'absent',
+        }) }
+      end
+
+      context "keep_type='hours' and most parameters different from defaults" do
+        let(:params) {{
+          :host           => '127.0.1.1',
+          :keep_type      => 'hours',
+          :keep_amount    => 48,
+          :prefix         => 'my-logstash-',
+          :port           => 29199,
+          :es_timeout     => 60,
+          :log_file       => '/var/log/logstash/index_purge.log',
+          :cron_hour      => '*',
+          :cron_minute    => '*',
+          :cron_month     => 1,
+          :cron_monthday  => 2,
+          :cron_weekday   => 3
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::clean') }
+        it { 
+          cmd = []
+          cmd << '/usr/bin/curator_cli' <<
+                '--host 127.0.1.1' <<
+                '--port 29199' <<
+                '--timeout 60' <<
+                '--logfile /var/log/logstash/index_purge.log' <<
+                'delete_indices' <<
+                '--ignore_empty_list' <<
+                '--filter_list \'[{"filtertype":"age","source":"creation_date","direction":"older","unit":"hours","unit_count":48},{"filtertype":"pattern","kind":"prefix","value":"my-logstash-"}]\''
+
+          is_expected.to create_cron('logstash_index_cleanup').with({
+            :ensure   => 'present',
+            :command  => cmd.join(' '),
+            :hour     => '*',
+            :minute   => '*',
+            :month    => 1,
+            :monthday => 2,
+            :weekday  => 3,
+            :require  => 'Class[Simp_logstash::Curator]'
+          }) 
+        }
+      end
+
+      context "keep_type='space'" do
+        let(:params) {{
+          :keep_type => 'space',
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::clean') }
+        it { 
+          cmd = []
+          cmd << '/usr/bin/curator_cli' <<
+                '--host 127.0.0.1' <<
+                '--port 9199' <<
+                '--timeout 30' <<
+                '--logfile /var/log/logstash/curator_clean.log' <<
+                'delete_indices' <<
+                '--ignore_empty_list' <<
+                '--filter_list \'[{"filtertype":"space","disk_space":356},{"filtertype":"pattern","kind":"prefix","value":"logstash-"}]\''
+
+          is_expected.to create_cron('logstash_index_cleanup').with({
+            :ensure   => 'present',
+            :command  => cmd.join(' '),
+            :hour     => 1,
+            :minute   => 15,
+            :month    => '*',
+            :monthday => '*',
+            :weekday  => '*',
+            :require  => 'Class[Simp_logstash::Curator]'
+          }) 
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,68 +1,114 @@
 require 'spec_helper'
 
+shared_examples_for 'a simp_logstash profile' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('simp_logstash') }
+  it { is_expected.to create_class('java') }
+  it { is_expected.to create_class('logstash') }
+end
+
+
 describe 'simp_logstash' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts){ facts }
 
-      context "on #{os}" do
-        let(:params) {{
-          :pki    => 'simp',
-          :inputs => ['tcp_syslog_tls','syslog','tcp_json_tls'],
-        }}
+      context 'with default parameters' do
+        let(:params) { {} }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('simp_logstash') }
-        it { is_expected.to create_simp_logstash__input('syslog') }
+        it_should_behave_like 'a simp_logstash profile'
+
         it { is_expected.to create_simp_logstash__input('tcp_syslog_tls') }
-        it { is_expected.to create_simp_logstash__input('tcp_json_tls') }
-
         it {
           is_expected.to create_file(
             '/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_syslog_tls.conf'
-          ).without_content(/=>\s*$/)
+          )
         }
-        it {
-          is_expected.to create_file(
-            '/etc/logstash/conf.d/simp-logstash-10_input-50-syslog.conf'
-          ).without_content(/=>\s*$/)
-        }
-        it {
-          is_expected.to create_file(
-            '/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_json_tls.conf'
-          ).without_content(/=>\s*$/)
-        }
+
+        # order on this filter is 10
+        it { is_expected.to create_simp_logstash__filter('simp_syslog') }
         it {
           is_expected.to create_file(
             '/etc/logstash/conf.d/simp-logstash-20_filter-10-simp_syslog.conf'
-          ).without_content(/=>\s*$/)
+          )
+        }
+
+        # order on these filters is 10
+        #TODO add in 'slapd_audit' when this filter is fixed
+        ['audispd', 'puppet_agent', 'puppet_server', 'sshd', 'sudosh',
+            'httpd', 'yum'].each do |filter|
+          it { is_expected.to create_simp_logstash__filter(filter) }
+          it {
+            filename = "/etc/logstash/conf.d/simp-logstash-20_filter-50-#{filter}.conf"
+            is_expected.to create_file(filename)
+           }
+        end
+
+        it { is_expected.to create_simp_logstash__output('elasticsearch') }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf'
+          )
+        }
+
+        # Even though we haven't specfied pki = 'simp' or pki = 'true', the
+        # default input (TLS-based) includes the simp_logstash::config::pki
+        # class, which in turn, does nothing because pki = false
+        it { is_expected.to contain_class('simp_logstash::config::pki') }
+        it { is_expected.to_not contain_pki__copy('logstash')}
+        it { is_expected.to_not contain_class('pki')}
+
+        it { is_expected.to_not create_class('iptables') }
+        it { is_expected.to_not create_iptables__listen__tcp_stateful('allow_tcp_syslog_tls')}
+      end
+
+      context "with pki=simp, firewall=ture and custom inputs, outputs, filters" do
+        let(:params) {{
+          :pki      => 'simp',
+          :firewall => true,
+          :inputs   => ['stdin','syslog','tcp_json_tls'],
+          :filters  => [ 'sudosh', 'simp_syslog' ],
+          :outputs  => [ 'file' ]
+        }}
+
+        it_should_behave_like 'a simp_logstash profile'
+        ['stdin', 'syslog', 'tcp_json_tls'].each do |input|
+          it { is_expected.to create_simp_logstash__input(input) }
+          it {
+            filename = "/etc/logstash/conf.d/simp-logstash-10_input-50-#{input}.conf"
+            is_expected.to create_file(filename)
+           }
+        end
+
+        it { is_expected.to create_simp_logstash__filter('simp_syslog') }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-20_filter-10-simp_syslog.conf'
+          )
+        }
+
+        it { is_expected.to create_simp_logstash__filter('sudosh') }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-20_filter-50-sudosh.conf'
+          )
+        }
+        it { is_expected.to create_simp_logstash__output('file') }
+        it {
+          is_expected.to create_file(
+            '/etc/logstash/conf.d/simp-logstash-30_output-30-file.conf'
+          )
         }
 
         it { is_expected.to contain_class('simp_logstash::config::pki') }
         it { is_expected.to contain_class('pki')}
         it { is_expected.to create_file('/etc/pki/simp_apps/logstash/x509')}
 
+        it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
         it { is_expected.to create_class('iptables') }
-
         it { is_expected.to create_iptables_rule('tcp_logstash_syslog_redirect')}
-
-        it {
-          is_expected.to create_file(
-            '/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf'
-          ).without_content(/=>\s*$/)
-        }
-
-        it { is_expected.to create_simp_logstash__filter('sshd') }
-        it { is_expected.to create_simp_logstash__filter('yum') }
-        it { is_expected.to create_simp_logstash__filter('audispd') }
-        it { is_expected.to create_simp_logstash__filter('httpd') }
-        it { is_expected.to create_simp_logstash__filter('puppet_agent') }
-        it { is_expected.to create_simp_logstash__filter('puppet_server') }
-=begin
-        # Re-enable this once the slapd filter is fixed
-        it { is_expected.to create_simp_logstash__filter('slapd_audit') }
-=end
-        it { is_expected.to create_simp_logstash__output('elasticsearch') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('logstash_syslog_tcp')}
+        it { is_expected.to create_iptables_rule('logstash_syslog_tcp_allow')}
       end
     end
   end

--- a/spec/classes/input/stdin_spec.rb
+++ b/spec/classes/input/stdin_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe 'simp_logstash::input::stdin' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with default parameters' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::input::stdin') }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-stdin.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  stdin {
+    id => "simp_stdin"
+    type => "simp_stdin"
+  }
+}
+EOM
+        ) }
+
+        it { is_expected.to_not create_class('iptables') }
+      end
+
+      context 'with optional template parameters except content' do
+        let(:params) { {
+          :add_field      => { 'received_at' => '%{@timestamp}', 'received_from' => '%{host}' },
+          :codec          => 'json',
+          :enable_metric  => false,
+          :lstash_tags    => [ 'my_tag1', 'my_tag2' ],
+        } }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-stdin.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  stdin {
+    add_field => {
+      "received_at" => "%{@timestamp}"
+      "received_from" => "%{host}"
+    }
+
+    codec => "json"
+    enable_metric => false
+    id => "simp_stdin"
+    type => "simp_stdin"
+    tags => [ "my_tag1", "my_tag2" ]
+  }
+}
+EOM
+        ) }
+
+        it { is_expected.to_not create_class('iptables') }
+      end
+
+      context 'with content template parameter' do
+        let(:params) { {
+          :content => <<EOM
+input {
+  stdin { }
+}
+EOM
+        } }
+
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-stdin.conf').with_content(<<EOM
+input {
+  stdin { }
+}
+EOM
+        ) }
+      end
+    end
+  end
+end

--- a/spec/classes/input/syslog_spec.rb
+++ b/spec/classes/input/syslog_spec.rb
@@ -1,27 +1,149 @@
 require 'spec_helper'
 
+shared_examples_for 'a simp_logstash::input::syslog' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('simp_logstash::input::syslog') }
+  it { is_expected.to create_class('simp_logstash::filter::simp_syslog') }
+end
+
 describe 'simp_logstash::input::syslog' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts){ facts }
 
-      context "on #{os}" do
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_class('simp_logstash::input::syslog') }
-        it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
+      context 'with simp_logstash::firewall=false' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => false,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
 
-        context 'with listen_plain_tcp=true' do
-          let (:params) { {:listen_plain_tcp => true} }
+        context 'with default parameters' do
+          let(:params) { {} }
+          it_should_behave_like 'a simp_logstash::input::syslog'
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-syslog.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    host => "127.0.0.1"
+    port => 51400
+    id => "simp_syslog-tcp"
+    type => "simp_syslog"
+  }
+
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+          it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
+        end
+
+        context 'with optional template parameters except content and listen_plain_udp=true' do
+          let(:params) { {
+            :add_field      => { 'received_at' => '%{@timestamp}', 'received_from' => '%{host}' },
+            :codec          => 'json',
+            :enable_metric  => false,
+            :lstash_tags    => [ 'my_tag1', 'my_tag2' ],
+            :proxy_protocol => false,
+            :listen_plain_udp => true
+          } }
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-syslog.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    add_field => {
+      "received_at" => "%{@timestamp}"
+      "received_from" => "%{host}"
+    }
+
+    codec => "json"
+    host => "127.0.0.1"
+    port => 51400
+    proxy_protocol => false
+    id => "simp_syslog-tcp"
+    type => "simp_syslog"
+    tags => [ "my_tag1", "my_tag2" ]
+    enable_metric => false
+  }
+
+  udp {
+    add_field => {
+      "received_at" => "%{@timestamp}"
+      "received_from" => "%{host}"
+    }
+    codec => "json"
+    host => "127.0.0.1"
+    port => 51400
+    proxy_protocol => false
+    id => "simp_syslog-udp"
+    type => "simp_syslog"
+    tags => [ "my_tag1", "my_tag2" ]
+    enable_metric => false
+  }
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+          it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
+        end
+
+        context 'with content template parameter' do
+          let(:params) { {
+            :content => <<EOM
+input {
+  syslog { }
+}
+EOM
+          } }
+
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-syslog.conf').with_content(<<EOM
+input {
+  syslog { }
+}
+EOM
+          ) }
+        end
+      end
+
+      context 'with simp_logstash::firewall=true' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => true,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
+
+        context 'with default parameters' do
+          let(:params) { {} }
+          it_should_behave_like 'a simp_logstash::input::syslog'
+          it { is_expected.to create_class('iptables') }
+          it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
+          it { is_expected.to create_iptables_rule('tcp_logstash_syslog_redirect') }
+          it { is_expected.to_not create_iptables_rule('udp_logstash_syslog_redirect') }
           it { is_expected.to create_sysctl('net.ipv4.conf.all.route_localnet') }
         end
 
+        context 'with listen_plain_tcp=false' do
+          let(:params) { {:listen_plain_tcp => false} }
+          it { is_expected.to_not create_iptables_rule('tcp_logstash_syslog_redirect') }
+        end
+
         context 'with listen_plain_udp=true' do
-          let (:params) { {:listen_plain_udp => true} }
+          let(:params) { {:listen_plain_udp => true} }
           it { is_expected.to create_iptables_rule('udp_logstash_syslog_redirect')}
         end
 
         context 'with manage_sysctl=false' do
-          let (:params) { {:manage_sysctl => false} }
+          let(:params) { {:manage_sysctl => false} }
           it { is_expected.to_not create_sysctl('net.ipv4.conf.all.route_localnet') }
         end
       end

--- a/spec/classes/input/tcp_json_tls_spec.rb
+++ b/spec/classes/input/tcp_json_tls_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+
+shared_examples_for 'a simp_logstash::input::tcp_json_tls' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('simp_logstash::input::tcp_json_tls') }
+  it { is_expected.to create_class('simp_logstash::config::pki') }
+end
+
+describe 'simp_logstash::input::tcp_json_tls' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with simp_logstash::firewall=false' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => false,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
+
+        context 'with default parameters' do
+          let(:params) { {} }
+          it_should_behave_like 'a simp_logstash::input::tcp_json_tls'
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_json_tls.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    codec => "json"
+    host => "0.0.0.0"
+    port => 5140
+    id => "simp_tcp_json_tls"
+    type => "json"
+    ssl_enable => true
+    ssl_verify => true
+    ssl_extra_chain_certs => [ "/etc/pki/simp_apps/logstash/x509/cacerts/cacerts.pem" ]
+    ssl_key   => "/etc/pki/simp_apps/logstash/x509/private/foo.example.com.pem"
+    ssl_cert  => "/etc/pki/simp_apps/logstash/x509/public/foo.example.com.pub"
+  }
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+        end
+
+        context 'with optional template parameters except content' do
+          let(:params) { {
+            :add_field      => { 'received_at' => '%{@timestamp}', 'received_from' => '%{host}' },
+            :enable_metric  => false,
+            :lstash_tags    => [ 'my_tag1', 'my_tag2' ],
+            :proxy_protocol => false,
+          } }
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_json_tls.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    add_field => {
+      "received_at" => "%{@timestamp}"
+      "received_from" => "%{host}"
+    }
+    codec => "json"
+    host => "0.0.0.0"
+    port => 5140
+    proxy_protocol => false
+    id => "simp_tcp_json_tls"
+    tags => [ "my_tag1", "my_tag2" ]
+    type => "json"
+    enable_metric => false
+    ssl_enable => true
+    ssl_verify => true
+    ssl_extra_chain_certs => [ "/etc/pki/simp_apps/logstash/x509/cacerts/cacerts.pem" ]
+    ssl_key   => "/etc/pki/simp_apps/logstash/x509/private/foo.example.com.pem"
+    ssl_cert  => "/etc/pki/simp_apps/logstash/x509/public/foo.example.com.pub"
+  }
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+        end
+
+        context 'with content template parameter' do
+          let(:params) { {
+            :content => <<EOM
+input {
+  syslog { }
+}
+EOM
+          } }
+
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_json_tls.conf').with_content(<<EOM
+input {
+  syslog { }
+}
+EOM
+          ) }
+        end
+      end
+
+      context 'with simp_logstash::firewall=true' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => true,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
+
+        let(:params) { {} }
+        it_should_behave_like 'a simp_logstash::input::tcp_json_tls'
+        it { is_expected.to create_class('iptables') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('allow_tcp_json_tls') }
+      end
+    end
+  end
+end

--- a/spec/classes/input/tcp_syslog_tls_spec.rb
+++ b/spec/classes/input/tcp_syslog_tls_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+shared_examples_for 'a simp_logstash::input::tcp_syslog_tls' do
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('simp_logstash::input::tcp_syslog_tls') }
+  it { is_expected.to create_class('simp_logstash::config::pki') }
+  it { is_expected.to create_class('simp_logstash::filter::simp_syslog') }
+end
+
+describe 'simp_logstash::input::tcp_syslog_tls' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with simp_logstash::firewall=false' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => false,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
+
+        context 'with default parameters' do
+          let(:params) { {} }
+          it_should_behave_like 'a simp_logstash::input::tcp_syslog_tls'
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_syslog_tls.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    host => "0.0.0.0"
+    port => 6514
+    id => "simp_syslog_tls"
+    type => "simp_syslog"
+    ssl_enable => true
+    ssl_verify => true
+    ssl_extra_chain_certs => [ "/etc/pki/simp_apps/logstash/x509/cacerts/cacerts.pem" ]
+    ssl_key   => "/etc/pki/simp_apps/logstash/x509/private/foo.example.com.pem"
+    ssl_cert  => "/etc/pki/simp_apps/logstash/x509/public/foo.example.com.pub"
+  }
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+        end
+
+        context 'with optional template parameters except content' do
+          let(:params) { {
+            :add_field      => { 'received_at' => '%{@timestamp}', 'received_from' => '%{host}' },
+            :codec          => 'json',
+            :enable_metric  => false,
+            :lstash_tags    => [ 'my_tag1', 'my_tag2' ],
+            :proxy_protocol => false,
+          } }
+  it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_syslog_tls.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  tcp {
+    add_field => {
+      "received_at" => "%{@timestamp}"
+      "received_from" => "%{host}"
+    }
+    codec => "json"
+    host => "0.0.0.0"
+    port => 6514
+    proxy_protocol => false
+    id => "simp_syslog_tls"
+    tags => [ "my_tag1", "my_tag2" ]
+    type => "simp_syslog"
+    enable_metric => false
+    ssl_enable => true
+    ssl_verify => true
+    ssl_extra_chain_certs => [ "/etc/pki/simp_apps/logstash/x509/cacerts/cacerts.pem" ]
+    ssl_key   => "/etc/pki/simp_apps/logstash/x509/private/foo.example.com.pem"
+    ssl_cert  => "/etc/pki/simp_apps/logstash/x509/public/foo.example.com.pub"
+  }
+}
+EOM
+          ) }
+
+          it { is_expected.to_not create_class('iptables') }
+        end
+
+        context 'with content template parameter' do
+          let(:params) { {
+            :content => <<EOM
+input {
+  syslog { }
+}
+EOM
+          } }
+
+          it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-10_input-50-tcp_syslog_tls.conf').with_content(<<EOM
+input {
+  syslog { }
+}
+EOM
+          ) }
+        end
+      end
+
+      context 'with simp_logstash::firewall=true' do
+        let(:pre_condition){<<EOM
+class{'simp_logstash':
+  firewall => true,
+  trusted_nets => [ '1.2.0.0/16' ]
+}
+EOM
+        }
+
+        let(:params) { {} }
+        it_should_behave_like 'a simp_logstash::input::tcp_syslog_tls'
+        it { is_expected.to create_class('iptables') }
+        it { is_expected.to create_iptables__listen__tcp_stateful('allow_tcp_syslog_tls') }
+      end
+    end
+  end
+end

--- a/spec/classes/optimize_spec.rb
+++ b/spec/classes/optimize_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe 'simp_logstash::optimize' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with default parameters' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::optimize') }
+
+        it { 
+          cmd = []
+          cmd << '/usr/bin/curator_cli' <<
+                '--host 127.0.0.1' <<
+                '--port 9199' <<
+                '--timeout 21600' <<
+                '--logfile /var/log/logstash/curator_optimize.log' <<
+                'forcemerge' <<
+                '--max_num_segments 2' <<
+                '--ignore_empty_list' <<
+                '--filter_list \'[{"filtertype":"pattern","kind":"prefix","value":"logstash-"}]\''
+
+          is_expected.to create_cron('logstash_index_optimize').with({
+            :ensure   => 'present',
+            :command  => cmd.join(' '),
+            :hour     => 3,
+            :minute   => 15,
+            :month    => '*',
+            :monthday => '*',
+            :weekday  => '*',
+            :require  => 'Class[Simp_logstash::Curator]'
+          }) 
+        }
+      end
+
+      context "ensure='absent'" do
+        let(:params) {{
+          :ensure => 'absent'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::optimize') }
+        it { is_expected.to create_cron('logstash_index_optimize').with({
+          :ensure => 'absent',
+        }) }
+      end
+
+      context "most parameters different from defaults" do
+        let(:params) {{
+          :host             => '127.0.1.1',
+          :prefix           => 'my-logstash-',
+          :port             => 29199,
+          :es_timeout       => 1000,
+          :max_num_segments => 5,
+          :log_file         => '/var/log/logstash/index_forcemerge.log',
+          :cron_hour        => '*',
+          :cron_minute      => '*',
+          :cron_month       => 1,
+          :cron_monthday    => 2,
+          :cron_weekday     => 3
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::optimize') }
+        it { 
+          cmd = []
+          cmd << '/usr/bin/curator_cli' <<
+                '--host 127.0.1.1' <<
+                '--port 29199' <<
+                '--timeout 1000' <<
+                '--logfile /var/log/logstash/index_forcemerge.log' <<
+                'forcemerge' <<
+                '--max_num_segments 5' <<
+                '--ignore_empty_list' <<
+                '--filter_list \'[{"filtertype":"pattern","kind":"prefix","value":"my-logstash-"}]\''
+
+          is_expected.to create_cron('logstash_index_optimize').with({
+            :ensure   => 'present',
+            :command  => cmd.join(' '),
+            :hour     => '*',
+            :minute   => '*',
+            :month    => 1,
+            :monthday => 2,
+            :weekday  => 3,
+            :require  => 'Class[Simp_logstash::Curator]'
+          }) 
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/output/elasticsearch_spec.rb
+++ b/spec/classes/output/elasticsearch_spec.rb
@@ -1,0 +1,211 @@
+require 'spec_helper'
+
+describe 'simp_logstash::output::elasticsearch' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with default parameters' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::output::elasticsearch') }
+        it { is_expected.to_not create_class('stunnel') }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  elasticsearch {
+    hosts => [ "127.0.0.1:9199" ]
+    id => "simp_elasticsearch"
+  }
+}
+EOM
+        ) }
+      end
+
+      context 'with same host specified for ES host' do
+        let(:params) { {
+          :host => facts[:fqdn]
+        } }
+
+        it { is_expected.to_not create_class('stunnel') }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  elasticsearch {
+    hosts => [ "127.0.0.1:9199" ]
+    id => "simp_elasticsearch"
+  }
+}
+EOM
+       ) }
+      end
+
+      context 'with different ES host specified' do
+        let(:params) { {
+          :host => '8.8.8.8'
+        } }
+        it { is_expected.to create_class('stunnel') }
+        it { is_expected.to create_stunnel__connection('logstash_elasticsearch').with( {
+          'connect' => ['8.8.8.8:9200'],
+          'accept'  => '127.0.0.1:9200'
+        } ) }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  elasticsearch {
+    hosts => [ "127.0.0.1:9200" ]
+    id => "simp_elasticsearch"
+  }
+}
+EOM
+       ) }
+      end
+
+      context 'with stunnel_elasticsearch=false and different ES host specified' do
+        let(:params) { {
+          :stunnel_elasticsearch => false,
+          :host                  => '8.8.8.8'
+        } }
+
+        it { is_expected.to_not create_class('stunnel') }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  elasticsearch {
+    hosts => [ "8.8.8.8:9199" ]
+    id => "simp_elasticsearch"
+  }
+}
+EOM
+       ) }
+      end
+
+      context 'with optional template parameters except content' do
+        let(:params) { {
+          :absolute_healthcheck_path      => true,
+          :action                         => 'create',
+          :codec                          => 'json',
+          :doc_as_upsert                  => true,
+          :document_id                    => 'doc-123',
+          :document_type                  => 'lstash',
+          :enable_metric                  => false,
+          :failure_type_logging_whitelist => [
+            'document_already_exists_exception',
+            'es_rejected_execution_exception'
+          ],
+          :flush_size                     => 100,
+          :healthcheck_path               => '/some/path/to/healthcheck',
+          :idle_flush_time                => 2,
+          :index                          => 'simp-events-%{+YYY.MM.dd}',
+          :manage_template                => false,
+          :parameters                     => { 'param1'=> 'value1', 'param2' => 'value2' },
+          :parent                         => 'my-parent',
+          :path                           => '/some/path',  #is this actually a url?
+          :pipeline                       => '%{INGEST_PIPELINE}',
+          :pool_max                       => 10,
+          :pool_max_per_route             => 2,
+          :resurrect_delay                => 3,
+          :retry_initial_interval         => 4,
+          :retry_max_interval             => 10,
+          :retry_on_conflict              => 2,
+          :routing                        => 'my-routing-override',
+          :script                         => 'update-script',
+          :script_lang                    => 'ruby',
+          :script_type                    => [ 'indexed', 'file'],
+          :script_var_name                => 'simp-event',
+          :scripted_upsert                => true,
+          :template                       => '/my/path/to/template',
+          :template_name                  => 'simp-logstash',
+          :template_overwrite             => true,
+          :timeout                        => 120,
+          :upsert                         => 'document {}',
+          :validate_after_inactivity      => 14000,
+          :version                        => '1.2',
+          :version_type                   => 'internal',
+          :workers                        => 3
+        } }
+
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  elasticsearch {
+    absolute_healthcheck_path => true
+    action => "create"
+    codec => "json"
+    doc_as_upsert => true
+    document_id => "doc-123"
+    document_type => "lstash"
+    enable_metric => false
+    failure_type_logging_whitelist => [ "document_already_exists_exception", "es_rejected_execution_exception" ]
+    flush_size => 100
+    healthcheck_path => "/some/path/to/healthcheck"
+    hosts => [ "127.0.0.1:9199" ]
+    id => "simp_elasticsearch"
+    idle_flush_time => 2
+    index => "simp-events-%{+YYY.MM.dd}"
+    manage_template => false
+    parameters => {
+      "param1" => "value1"
+      "param2" => "value2"
+    }
+    parent => "my-parent"
+    path => "/some/path"
+    pipeline => "%{INGEST_PIPELINE}"
+    pool_max => 10
+    pool_max_per_route => 2
+    resurrect_delay => 3
+    retry_initial_interval => 4
+    retry_max_interval => 10
+    retry_on_conflict => 2
+    routing => "my-routing-override"
+    script => "update-script"
+    script_lang => "ruby"
+    script_type => "["indexed", "file"]"
+    script_var_name => "simp-event"
+    scripted_upsert => true
+    template => "/my/path/to/template"
+    template_name => "simp-logstash"
+    template_overwrite => true
+    timeout => 120
+    upsert => "document {}"
+    validate_after_inactivity => 14000
+    version => "1.2"
+    version_type => "internal"
+    workers => 3
+  }
+}
+EOM
+        ) }
+      end
+
+      context 'with content template parameter' do
+        let(:params) { {
+          :content => <<EOM
+output {
+elasticsearch { }
+}
+EOM
+        } }
+
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-50-elasticsearch.conf').with_content(<<EOM
+output {
+elasticsearch { }
+}
+EOM
+        ) }
+      end
+
+    end
+  end
+end

--- a/spec/classes/output/file_spec.rb
+++ b/spec/classes/output/file_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'simp_logstash::output::file' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
+
+      context 'with default parameters' do
+        let(:params) { {} }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('simp_logstash::output::file') }
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-30-file.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  file {
+    path => "/var/log/logstash/file_output.log"
+    id => "simp_file"
+  }
+}
+EOM
+        ) }
+      end
+
+      context 'with optional template parameters except content' do
+        let(:params) { {
+          :codec             => 'json',
+          :create_if_deleted => true,
+          :dir_mode          => 0750,
+          :enable_metric     => false,
+          :file_mode         => 0640,
+          :filename_failure  => 'filepath_failures_backup',
+          :flush_interval    => 0,
+          :gzip              => true,
+          :workers           => 3
+        } }
+
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-30-file.conf').with_content(<<EOM
+# This file managed by Puppet
+# Any changes will be overwritten
+
+output {
+  file {
+    path => "/var/log/logstash/file_output.log"
+    codec => "json"
+    create_if_deleted => true
+    dir_mode => 0750
+    enable_metric => false
+    file_mode => 0640
+    filename_failure => filepath_failures_backup
+    flush_interval => 0
+    gzip => true
+    id => "simp_file"
+    workers => 3
+  }
+}
+EOM
+        ) }
+      end
+
+      context 'with content template parameter' do
+        let(:params) { {
+          :content => <<EOM
+output {
+syslog { }
+}
+EOM
+        } }
+
+        it { is_expected.to create_file('/etc/logstash/conf.d/simp-logstash-30_output-30-file.conf').with_content(<<EOM
+output {
+syslog { }
+}
+EOM
+        ) }
+      end
+    end
+  end
+end

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,6 +1,2 @@
 ---
-
-logstash::logstash_user : 'logstash'
-logstash::logstash_group : 'logstash'
-
-simp_options::pki: 'simp'
+nothing_to_set_here: true

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,6 +4,40 @@ require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
+# Wait up to max_wait_seconds for a message to be logged on a host or fail
+# @param [String] host Name of test server on which the log file resides
+# @param [String] log Fully qualified path to log on the test server
+# @param [String] message Message to search for within the test server's log
+# @param [Float]  max_wait_seconds Maximum number of seconds to wait for the
+#                                  message to be found in the log before failing
+# @param [Float]  interval_sec Interval in seconds between log checks
+#
+# TODO move to Simp::BeakerHelpers
+require 'timeout'
+def wait_for_log_message(
+    host,
+    log,
+    message,
+    max_wait_seconds = (ENV['SIMPTEST_WAIT_FOR_LOG_MAX'] ? ENV['SIMPTEST_WAIT_FOR_LOG_MAX'].to_f : 60.0),
+    interval_sec = (ENV['SIMPTEST_LOG_CHECK_INTERVAL'] ? ENV['SIMPTEST_LOG_CHECK_INTERVAL'].to_f : 1.0)
+  )
+  result = nil
+  Timeout::timeout(max_wait_seconds) do
+    while true
+      result = on host, "grep '#{message}' #{log}", :accept_all_exit_codes => true
+      return if result.exit_code == 0
+      sleep(interval_sec)
+    end
+  end
+rescue Timeout::Error => e
+  error_msg = "Failed to find '#{message}' in #{log} on #{host} within #{max_wait_seconds} seconds:\n"
+  error_msg += "\texit_code = #{result.exit_code}\n"
+  error_msg += "\tstdout = \"#{result.stdout}\"\n" unless result.stdout.nil? or result.stdout.strip.empty?
+  error_msg += "\tstderr = \"#{result.stderr}\"" unless result.stderr.nil? or result.stderr.strip.empty?
+  fail error_msg
+end
+
+
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
     # Install Puppet

--- a/templates/filter/audispd.erb
+++ b/templates/filter/audispd.erb
@@ -2,7 +2,7 @@
 # Any changes will be overwritten
 
 filter {
-# These need to be combined or made more effecient in the future.  Could slow
+# These need to be combined or made more efficient in the future.  Could slow
 # down log flow on high volume systems.
   if [program] == "audispd" {
     grok {

--- a/templates/filter/httpd.erb
+++ b/templates/filter/httpd.erb
@@ -1,3 +1,6 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 filter {
   if [program] == "httpd" {
     grok {

--- a/templates/filter/puppet_agent.erb
+++ b/templates/filter/puppet_agent.erb
@@ -2,9 +2,9 @@
 # Any changes will be overwritten
 
 filter {
-  if [program] == "puppet-agent"  and [message] =~ "^Finished" {
+  if [program] == "puppet-agent"  and [message] =~ "^Applied" {
     grok {
-      match => {"message" => "Finished catalog run in %{NUMBER:puppet_agent_runtime} seconds"}
+      match => {"message" => "Applied catalog in %{NUMBER:puppet_agent_runtime} seconds"}
     }
   }
   if [program] == "puppet-agent" and  [message] =~ "Svckill" {

--- a/templates/filter/simp_syslog.erb
+++ b/templates/filter/simp_syslog.erb
@@ -1,11 +1,11 @@
 # This file managed by Puppet
-# # Any changes will be overwritten
+# Any changes will be overwritten
 
 filter {
   if [type] == "simp_syslog" {
     grok {
       match => {"message" => "<%%{POSINT:priority}>%{SYSLOGLINE}"}
-      overwrite => "message"
+      overwrite => [ "message" ]
       tag_on_failure => ["_grokparsefailure_sysloginput"]
     }
     syslog_pri {

--- a/templates/filter/slapd_audit.erb
+++ b/templates/filter/slapd_audit.erb
@@ -11,7 +11,7 @@ filter {
     }
     grok {
       match => {"message" => "changetype: %{WORD:ldap_changetype}"}
-      # LDAP Modfies happen often so we should figure out what changed.
+      # LDAP Modifies happen often so we should figure out what changed.
       match => {"message" => "(delete|replace): %{WORD:ldap_modify}"}
     }
   }

--- a/templates/filter/sshd.erb
+++ b/templates/filter/sshd.erb
@@ -5,7 +5,7 @@ filter {
   if [program] == "sshd" {
     grok {
       match => {"message" => "%{WORD:ssh_status} %{WORD:ssh_auth_type} for %{USER:user} from %{IP:src_ip} port %{NUMBER:src_port} %{WORD:src_protocol}"}
-      match => {"message" => "invalid user %{USER:user} from %{IP:src_ip}"}
+      match => {"message" => "Invalid user %{USER:user} from %{IP:src_ip}"}
     }
   }
 }

--- a/templates/filter/yum.erb
+++ b/templates/filter/yum.erb
@@ -1,3 +1,6 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 filter {
   if [program] == "yum" {
     grok {

--- a/templates/input/stdin.erb
+++ b/templates/input/stdin.erb
@@ -1,0 +1,29 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
+input {
+  stdin {
+<% unless @add_field.nil? || @add_field.empty? -%>
+    add_field => {
+      <%=
+      @add_field.keys.map do |k|
+        k = %("#{k}" => "#{@add_field[k]}")
+      end.join("\n      ") %>
+    }
+
+<% end -%>
+<% unless @codec.nil? -%>
+    codec => "<%= @codec %>"
+<% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
+<% end -%>
+    id => "<%= @id %>"
+<% unless @lstash_type.nil? -%>
+    type => "<%= @lstash_type %>"
+<% end -%>
+<% unless @lstash_tags.nil? || @lstash_tags.empty? -%>
+    tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
+  }
+}

--- a/templates/input/syslog.erb
+++ b/templates/input/syslog.erb
@@ -1,38 +1,47 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 input {
 <% if @listen_plain_tcp -%>
   tcp {
-<% unless @add_field.nil? -%>
+<% unless @add_field.nil? || @add_field.empty? -%>
     add_field => {
-    <%=
+      <%=
       @add_field.keys.map do |k|
         k = %("#{k}" => "#{@add_field[k]}")
-      end.join("\n      ")
-    %>
+      end.join("\n      ") %>
     }
+
 <% end -%>
 <% unless @codec.nil? -%>
     codec => "<%= @codec %>"
 <% end -%>
     host => "<%= @host %>"
     port => <%= @daemon_port %>
+<% unless @proxy_protocol.nil? -%>
+    proxy_protocol => <%= @proxy_protocol %>
+<% end -%>
+    id => "<%= @id %>-tcp"
 <% unless @lstash_type.nil? -%>
     type => "<%= @lstash_type %>"
 <% end -%>
-<% unless @lstash_tags.nil? -%>
+<% unless @lstash_tags.nil? || @lstash_tags.empty? -%>
     tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
 <% end -%>
   }
 <% end -%>
 
 <% if @listen_plain_udp -%>
   udp {
-<% unless @add_field.nil? -%>
+<% unless @add_field.nil? || @add_field.empty? -%>
     add_field => {
-    <%=
+      <%=
       @add_field.keys.map do |k|
         k = %("#{k}" => "#{@add_field[k]}")
-      end.join("\n      ")
-    %>
+      end.join("\n      ") %>
     }
 <% end -%>
 <% unless @codec.nil? -%>
@@ -40,11 +49,18 @@ input {
 <% end -%>
     host => "<%= @host %>"
     port => <%= @daemon_port %>
+<% unless @proxy_protocol.nil? -%>
+    proxy_protocol => <%= @proxy_protocol %>
+<% end -%>
+    id => "<%= @id %>-udp"
 <% unless @lstash_type.nil? -%>
     type => "<%= @lstash_type %>"
 <% end -%>
-<% unless @lstash_tags.nil? -%>
+<% unless @lstash_tags.nil? || @lstash_tags.empty? -%>
     tags => [ "<%= @lstash_tags.join('", "') %>" ]
+<% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
 <% end -%>
   }
 <% end -%>

--- a/templates/input/tcp_json_tls.erb
+++ b/templates/input/tcp_json_tls.erb
@@ -1,12 +1,14 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 input {
   tcp {
-<% unless @add_field.nil? -%>
+<% unless @add_field.nil? || @add_field.empty? -%>
     add_field => {
-    <%=
+      <%=
       @add_field.keys.map do |k|
         k = %("#{k}" => "#{@add_field[k]}")
-      end.join("\n      ")
-    %>
+      end.join("\n      ") %>
     }
 <% end -%>
 <% unless @codec.nil? -%>
@@ -14,15 +16,22 @@ input {
 <% end -%>
     host => "<%= @host %>"
     port => <%= @daemon_port %>
-<% unless @lstash_tags.nil? -%>
+<% unless @proxy_protocol.nil? -%>
+    proxy_protocol => <%= @proxy_protocol %>
+<% end -%>
+    id => "<%= @id %>"
+<% unless @lstash_tags.nil? || @lstash_tags.empty? -%>
     tags => [ "<%= @lstash_tags.join('", "') %>" ]
 <% end -%>
 <% unless @lstash_type.nil? -%>
     type => "<%= @lstash_type %>"
 <% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
+<% end -%>
     ssl_enable => true
     ssl_verify => <%= @ssl_verify %>
-    ssl_extra_chain_certs => "<%= @lstash_tls_cacerts %>"
+    ssl_extra_chain_certs => [ "<%= @lstash_tls_cacerts %>" ]
     ssl_key   => "<%= @lstash_tls_key %>"
     ssl_cert  => "<%= @lstash_tls_cert %>"
   }

--- a/templates/input/tcp_syslog_tls.erb
+++ b/templates/input/tcp_syslog_tls.erb
@@ -1,12 +1,14 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 input {
   tcp {
-<% unless @add_field.nil? -%>
+<% unless @add_field.nil? || @add_field.empty? -%>
     add_field => {
-    <%=
+      <%=
       @add_field.keys.map do |k|
         k = %("#{k}" => "#{@add_field[k]}")
-      end.join("\n      ")
-    %>
+      end.join("\n      ") %>
     }
 <% end -%>
 <% unless @codec.nil? -%>
@@ -14,15 +16,22 @@ input {
 <% end -%>
     host => "<%= @host %>"
     port => <%= @daemon_port %>
-<% unless @lstash_tags.nil? -%>
+<% unless @proxy_protocol.nil? -%>
+    proxy_protocol => <%= @proxy_protocol %>
+<% end -%>
+    id => "<%= @id %>"
+<% unless @lstash_tags.nil? || @lstash_tags.empty? -%>
     tags => [ "<%= @lstash_tags.join('", "') %>" ]
 <% end -%>
 <% unless @lstash_type.nil? -%>
     type => "<%= @lstash_type %>"
 <% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
+<% end -%>
     ssl_enable => true
     ssl_verify => <%= @ssl_verify %>
-    ssl_extra_chain_certs => "<%= @lstash_tls_cacerts %>"
+    ssl_extra_chain_certs => [ "<%= @lstash_tls_cacerts %>" ]
     ssl_key   => "<%= @lstash_tls_key %>"
     ssl_cert  => "<%= @lstash_tls_cert %>"
   }

--- a/templates/output/elasticsearch.erb
+++ b/templates/output/elasticsearch.erb
@@ -1,5 +1,11 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 output {
   elasticsearch {
+<% unless @absolute_healthcheck_path.nil? -%>
+    absolute_healthcheck_path => <%= @absolute_healthcheck_path %>
+<% end -%>
 <% unless @action.nil? -%>
     action => "<%= @action %>"
 <% end -%>
@@ -15,10 +21,20 @@ output {
 <% unless @document_type.nil? -%>
     document_type => "<%= @document_type %>"
 <% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
+<% end -%>
+<% unless @failure_type_logging_whitelist.nil? || @failure_type_logging_whitelist.empty?-%>
+    failure_type_logging_whitelist => [ "<%= @failure_type_logging_whitelist.join('", "') %>" ]
+<% end -%>
 <% unless @flush_size.nil? -%>
     flush_size => <%= @flush_size %>
 <% end -%>
+<% unless @healthcheck_path.nil? -%>
+    healthcheck_path => "<%= @healthcheck_path %>"
+<% end -%>
     hosts => [ "<%= @_host %>:<%= @_port %>" ]
+    id => "<%= @id %>"
 <% unless @idle_flush_time.nil? -%>
     idle_flush_time => <%= @idle_flush_time %>
 <% end -%>
@@ -28,14 +44,40 @@ output {
 <% unless @manage_template.nil? -%>
     manage_template => <%= @manage_template %>
 <% end -%>
+<% unless @parameters.nil? || @parameters.empty? -%>
+    parameters => {
+      <%=
+      @parameters.keys.map do |k|
+        k = %("#{k}" => "#{@parameters[k]}")
+      end.join("\n      ") %>
+    }
+<% end -%>
 <% unless @parent.nil? -%>
     parent => "<%= @parent %>"
 <% end -%>
 <% unless @path.nil? -%>
     path => "<%= @path %>"
 <% end -%>
+<% unless @pipeline.nil? -%>
+    pipeline => "<%= @pipeline %>"
+<% end -%>
+<% unless @pool_max.nil? -%>
+    pool_max => <%= @pool_max %>
+<% end -%>
+<% unless @pool_max_per_route.nil? -%>
+    pool_max_per_route => <%= @pool_max_per_route %>
+<% end -%>
+<% unless @resurrect_delay.nil? -%>
+    resurrect_delay => <%= @resurrect_delay %>
+<% end -%>
+<% unless @retry_initial_interval.nil? -%>
+    retry_initial_interval => <%= @retry_initial_interval %>
+<% end -%>
 <% unless @retry_max_interval.nil? -%>
     retry_max_interval => <%= @retry_max_interval %>
+<% end -%>
+<% unless @retry_on_conflict.nil? -%>
+    retry_on_conflict => <%= @retry_on_conflict %>
 <% end -%>
 <% unless @routing.nil? -%>
     routing => "<%= @routing %>"
@@ -46,7 +88,7 @@ output {
 <% unless @script_lang.nil? -%>
     script_lang => "<%= @script_lang %>"
 <% end -%>
-<% unless @script_type.nil? -%>
+<% unless @script_type.nil?  || @script_type.empty? -%>
     script_type => "<%= @script_type %>"
 <% end -%>
 <% unless @script_var_name.nil? -%>
@@ -69,6 +111,15 @@ output {
 <% end -%>
 <% unless @upsert.nil? -%>
     upsert => "<%= @upsert %>"
+<% end -%>
+<% unless @validate_after_inactivity.nil? -%>
+    validate_after_inactivity => <%= @validate_after_inactivity %>
+<% end -%>
+<% unless @version.nil? -%>
+    version => "<%= @version %>"
+<% end -%>
+<% unless @version_type.nil? -%>
+    version_type => "<%= @version_type %>"
 <% end -%>
 <% unless @workers.nil? -%>
     workers => <%= @workers %>

--- a/templates/output/file.erb
+++ b/templates/output/file.erb
@@ -1,3 +1,6 @@
+# This file managed by Puppet
+# Any changes will be overwritten
+
 output {
   file {
     path => "<%= @path %>"
@@ -8,10 +11,13 @@ output {
     create_if_deleted => <%= @create_if_deleted %>
 <% end -%>
 <% unless @dir_mode.nil? -%>
-    dir_mode => <%= @dir_mode %>
+    dir_mode => <%= sprintf("%#o", @dir_mode) %>
+<% end -%>
+<% unless @enable_metric.nil? -%>
+    enable_metric => <%= @enable_metric %>
 <% end -%>
 <% unless @file_mode.nil? -%>
-    file_mode => <%= @file_mode %>
+    file_mode => <%= sprintf("%#o", @file_mode) %>
 <% end -%>
 <% unless @filename_failure.nil? -%>
     filename_failure => <%= @filename_failure %>
@@ -22,6 +28,7 @@ output {
 <% unless @gzip.nil? -%>
     gzip => <%= @gzip %>
 <% end -%>
+    id => "<%= @id %>"
 <% unless @workers.nil? -%>
     workers => <%= @workers %>
 <% end -%>


### PR DESCRIPTION
- Code changes
  - Propagated logstash parameter name change ($configdir -> $config_dir)
  - Updated tcp/udp-based inputs with following settings:
      enable_metric
      id
      proxy_protocol
  - Updated elasticsearch output with the following settings:
      absolute_healthcheck_path
      enable_metric
      failure_type_logging_whitelist
      healthcheck_path
      id
      parameters
      pipeline
      pool_max
      pool_max_per_route
      resurrect_delay
      retry_initial_interval
      retry_on_conflict
      validate_after_inactivity
      version
      version_type
  - Updated file output with the following settings:
      enable_metric
      id
  - Fixed bug in input/stdin.pp whereby the content parameter was not
    properly used to generate th input plugin configuration.
  - Fixed type bug in simp_logstash::output::elasticsearch::action.  Type
    is a String (Enum) not  an Array of Strings.
  - Fixed bug in enum for simp_logstash::output::elasticsearch::script_type
  - Fixed bug in sshd grok rule for invalid user
  - Made sure firewall global catalyst is used to determine when to include
    iptables class and create iptables rules.
  - Adjusted formatting of file output's dir_mode and file_mode to be
    more user friendly (octal).
  - Eliminated trailing whitespace in most files

- Documentation changes
  - Updated comments in init.pp to reflect change from logstash::init_defaults to
    logstash::startup_options and logstash::java_options
  - Fixed puppet strings problems

- Added spec tests

- Acceptance testing updates/fixes
  - Updated YUM repo URL for elasticsearch and logstash
  - Removed OBE logstash::logstash_user and logstash::logstash_group hieradata
  - Added logic to ensure JAVA 8 is installed on el6 servers running logstash
    or elasticsearch
  - Specified provider in 'puppet resource service' actions for el6, as
    puppet assumes provider is SystemV, when in fact the provider is Upstart.
  - Added elasticsearch test suite to set of suites run by 'rake beaker:suites'
  - Minor tweaks (e.g., use of wait_for_log_message(), context/example names)
  - Pinned versions in .fixtures.yml

CAUTION! This project uses interim artifacts:
- pupmod-simp-simp_elasticsearch: Use SIMP-3048 PR from lnemsick-simp repo
  (code update to 5.X Elasticsearch) until PR is merged
- puppet-logstash: Use temporary version in lnemsick-simp repo until merge
  of elastic PR #330 ('Fixes for Puppet 4 strict_variables') is merged
  into the elastic repo and then propagated to simp fork.
- puppet-elasticsearch:  Use newer version from elastic repo for ES 5.4
  fixes, until that version is propagated to our fork.

UNADDRESSED ITEMS/ISSUES
- Did not add any of the unexposed settings to the filters, because
  unlike the inputs and outputs, the filters for the most part do
  not allow any tweaking.  The user only has the nuclear option
  to completely replace the filter content.
- Did not add id setting to each filter plugin. May want to do this
  to distinguish each grok/multiline/syslog_pri filter used in the
  set of filters.
- Did not address lack of tests for
  clean.pp, optimize.pp + curator.pp
  filter/audispd.pp
  filter/httpd.pp
  filter/puppet_agent.pp
  filter/puppet_server.pp
  filter/simp_syslog.pp
  filter/slapd_audit.pp