### PR TITLE
(SIMP-3372) simp_logstash - changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 - Fixed type bug in simp_logstash::output::elasticsearch::action.
 - Fixed enum typo in enum for simp_logstash::output::elasticsearch::script_type
 - Fixed puppet strings problems.
+- Confine puppet version in metadata.json
 
 * Fri Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 3.0.1-0
 - Removed pupmod-simp-sysctl in favor of augeas-sysctl

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Apr 05 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+* Tue May 09 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Updated to LogStash 5.X and Elasticsearch 5.X
 - Fixed type bug in simp_logstash::output::elasticsearch::action.
 - Fixed enum typo in enum for simp_logstash::output::elasticsearch::script_type


### PR DESCRIPTION
Last tag was 4.0.0, even though there is no entry in the CHANGELOG for it.
Looks like 3.0.0/3.0.1 CHANGELOG entries were intended to be 4.0.0...