### PR TITLE
(SIMP-4246) Update to puppetlabs/java 2.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,29 +19,29 @@ fixtures:
       ref: 2.2.0
     compliance_mapper: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
+      # master is beyond 4.1.1, but has breaking changes to
+      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 3.0.0
+      ref: 4.1.1
     datacat:
       repo: https://github.com/simp/puppet-datacat
       ref: simp6.0.0-0.6.2
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
-      ref: 5.2.0
+      ref: 5.5.0
     simp_elasticsearch: https://github.com/simp/pupmod-simp-simp_elasticsearch
     file_concat:
       repo: https://github.com/simp/puppet-lib-file_concat
       ref: simp6.0.0-1.0.1
-    haveged:
-      repo: https://github.com/simp/puppet-haveged
-      ref: 0.4.4
+    haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     java:
       repo: https://github.com/simp/puppetlabs-java
-      ref: simp-1.6.0-post1
+      ref: 2.4.0
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     logstash:
       repo: https://github.com/simp/puppet-logstash
-      branch: 5.2.1
+      ref: 5.3.0
     oddjob: https://github.com/simp/pupmod-simp-oddjob
     pam: https://github.com/simp/pupmod-simp-pam
     pki: https://github.com/simp/pupmod-simp-pki

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Feb 12 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.1-0
+- Update upperbound on puppetlabs/java version to < 3.0.0
+
 * Thu Nov 09 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.1-0
 - Adjust string match in acceptance test
 

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/java",
-      "version_requirement": ">= 1.2.0 < 2.0.0"
+      "version_requirement": ">= 1.2.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -68,6 +68,7 @@ simp_logstash::outputs :
         end
         set_hieradata_on(host, hdata)
         apply_manifest_on(host, manifest, :catch_failures => true)
+        on(host, 'rpm -q logstash')
       end
 
       it 'should be idempotent' do

--- a/spec/acceptance/suites/elasticsearch/00_base_spec.rb
+++ b/spec/acceptance/suites/elasticsearch/00_base_spec.rb
@@ -100,6 +100,7 @@ simp_logstash::outputs :
         # Reset the ES server to only allow this host through
         set_hieradata_on(host, hdata)
         apply_manifest_on(host, es_manifest)
+        on(host, 'rpm -q elasticsearch')
       end
 
       it 'should be idempotent' do


### PR DESCRIPTION
This update required an update to the latest 5.x versions of elastic/elasticsearch and elastic/logstash in the acceptance tests.
SIMP-4246 #comment simp_logstash update to puppetlabs/java 2.x