### PR TITLE
(SIMP-5305) updated $app_pki_external_source type

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ default:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
   script:
     - bundle exec rake beaker:suites[default]
 
@@ -206,7 +206,7 @@ default-fips:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
     BEAKER_fips: 'yes'
   script:
     - bundle exec rake beaker:suites[default]
@@ -218,7 +218,7 @@ elasticsearch:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
   script:
     - bundle exec rake beaker:suites[elasticsearch]
 
@@ -229,7 +229,7 @@ elasticsearch-fips:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '4.10'
+    PUPPET_VERSION: '~> 4.10.0'
     BEAKER_fips: 'yes'
   script:
     - bundle exec rake beaker:suites[elasticsearch]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 5.0.2-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Thu Jun 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 5.0.2-0
 - Update systemd fixtures and CI assets
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,7 +100,7 @@ class simp_logstash (
   Boolean                       $config_purge             = true,
   Simplib::Netlist              $trusted_nets             = simplib::lookup('simp_options::trusted_nets', {'default_value' =>   ['127.0.0.1/32'] }),
   Stdlib::Absolutepath          $app_pki_dir              = '/etc/pki/simp_apps/logstash/x509',
-  Stdlib::Absolutepath          $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                        $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath          $app_pki_key              = "${app_pki_dir}/private/${facts['fqdn']}.pem",
   Stdlib::Absolutepath          $app_pki_cert             = "${app_pki_dir}/public/${facts['fqdn']}.pub",
   Stdlib::Absolutepath          $app_pki_ca               = "${app_pki_dir}/cacerts/cacerts.pem",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated simp_logstash
SIMP-5305 #close