### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,11 +3,7 @@ fixtures:
   repositories:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     elasticsearch:
       repo: https://github.com/simp/puppet-elasticsearch
       ref: 5.5.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Mar 08 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.3-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.rst
+
 * Mon Nov 05 2018 Liz Nemsick <lnemsick-simp@gmail.com> - 5.0.2-0
 - Update contribution guide URL in README.rst
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ a compliance-management framework built on Puppet.
 If you find any issues, they can be submitted to our
 `JIRA <https://simp-project.atlassian.net/>`__.
 
-Please read our `Contribution Guide <http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html>`__.
+Please read our `Contribution Guide <https://simp.readthedocs.io/en/stable/contributors_guide/index.html>`__.
 
 As a component module, this module is not recommended for use outside of a SIMP
 environment but may work with some minor modification.
@@ -239,7 +239,7 @@ This module has only been tested on Red Hat Enterprise Linux 6 and 7 and CentOS
 Development
 -----------
 
-Please read our `Contribution Guide <http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html>`__.
+Please read our `Contribution Guide <https://simp.readthedocs.io/en/stable/contributors_guide/index.html>`__.
 
 Acceptance tests
 ^^^^^^^^^^^^^^^^

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_logstash",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "SIMP Team",
   "summary": "SIMP module for integrating elastic/puppet-logstash",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.rst

SIMP-6229 #comment pupmod-simp-simp_logstash